### PR TITLE
Migrate GTFS Digest scripts and confirm workability

### DIFF
--- a/_gtfs_curator_utils/gtfs_curator_utils/bq_utils.py
+++ b/_gtfs_curator_utils/gtfs_curator_utils/bq_utils.py
@@ -129,7 +129,12 @@ def bq_faster_download(sql_query: str, **kwargs) -> pd.DataFrame:
 
     docs.cloud.google.com/bigquery/docs/parameterized-queries
     """
-    client = bigquery.Client(credentials=credentials)
+    if "project" in kwargs:
+        project = kwargs.pop("project")
+    if "credentials" in kwargs:
+        credentials = kwargs.pop("credentials")
+
+    client = bigquery.Client(project=project, credentials=credentials)
 
     query_job = client.query(sql_query, **kwargs)
 
@@ -164,12 +169,23 @@ def set_bq_query_params(
 
     if scalar_query_parameter is not None:
         for column_name, column_value in scalar_query_parameter.items():
-            one_param = bigquery.ScalarQueryParameter(column_name, "STRING", column_value)
+            if isinstance(column_value, str):
+                one_param = bigquery.ScalarQueryParameter(column_name, "STRING", column_value)
+
+            elif isinstance(column_value, int):
+                one_param = bigquery.ScalarQueryParameter(column_name, "INT64", column_value)
+
             query_params.append(one_param)
 
     if array_query_parameter is not None:
         for column_name, column_list_of_values in array_query_parameter.items():
-            one_param = bigquery.ArrayQueryParameter(column_name, "STRING", column_list_of_values)
+            first_value = column_list_of_values[0]
+            if isinstance(first_value, str):
+                one_param = bigquery.ArrayQueryParameter(column_name, "STRING", column_list_of_values)
+
+            elif isinstance(first_value, int):
+                one_param = bigquery.ArrayQueryParameter(column_name, "INT64", column_list_of_values)
+
             query_params.append(one_param)
 
     return query_params

--- a/_gtfs_curator_utils/gtfs_curator_utils/bq_utils.py
+++ b/_gtfs_curator_utils/gtfs_curator_utils/bq_utils.py
@@ -40,7 +40,10 @@ def add_sql_date_filter(date_col: str, start_date: str, end_date: str) -> str:
     """
     Add a where condition to filter by date, coerce the dates so sql_query is read correctly.
     """
-    where_condition = f"{date_col} >= DATE('{start_date}') AND {date_col} <= DATE('{end_date}')"
+    if start_date == "" and end_date == "":
+        where_condition = ""
+    else:
+        where_condition = f"{date_col} >= DATE('{start_date}') AND {date_col} <= DATE('{end_date}')"
 
     return where_condition
 
@@ -99,10 +102,10 @@ def download_table(
     basic_query = basic_sql_query(project_name, dataset_name, table_name)
     date_condition = add_sql_date_filter(date_col, start_date, end_date)
 
-    if date_condition != "":
-        sql_query_statement = f"{basic_query} WHERE {date_condition}"
-    if date_condition == "":
+    if date_col is None:
         sql_query_statement = basic_query
+    if (date_col is not None) and (date_condition != ""):
+        sql_query_statement = f"{basic_query} WHERE {date_condition}"
 
     df = pandas_gbq.read_gbq(sql_query_statement, project_id=project_name, dialect="standard", credentials=credentials)
 

--- a/_gtfs_curator_utils/gtfs_curator_utils/bq_utils.py
+++ b/_gtfs_curator_utils/gtfs_curator_utils/bq_utils.py
@@ -9,7 +9,7 @@ import google.auth
 import pandas as pd
 import pandas_gbq
 from google.cloud import bigquery
-from gtfs_curator_utils import geography_utils
+from ridership_utils import geography_utils
 
 credentials, project = google.auth.default()
 
@@ -45,6 +45,42 @@ def add_sql_date_filter(date_col: str, start_date: str, end_date: str) -> str:
     return where_condition
 
 
+def exclude_interval_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    BigQuery has interval columns.
+    Drop these, because these will error when saving out parquets.
+    """
+    interval_cols = [c for c in df.columns if "_interval" in c]
+
+    return df.drop(columns=interval_cols)
+
+
+def fix_date_columns(
+    df: pd.DataFrame,
+    # allowed_date_cols: list = ["service_date", "date", "month_first_day"]
+) -> pd.DataFrame:
+    """
+    dbdate shows up when it's BigQuery DATE type.
+    For columns we do use, set these as datetime.
+
+    """
+    date_cols = df.select_dtypes("dbdate").columns.tolist()
+
+    df[date_cols] = df[date_cols].astype("datetime64[ns]")
+
+    return df
+
+
+def timezone_aware_datetime_columns(df, datetime_cols: list):
+    """
+    Timezone-aware columns need to be handled.
+
+    # these are timezone-aware, so should we localize to America/Los_Angeles or keep as UTC?
+    ["location_timestamp", "header_timestamp", "vehicle_timestamp"]
+    """
+    return
+
+
 def download_table(
     project_name: str = "cal-itp-data-infra",
     dataset_name: str = "mart_gtfs",
@@ -61,8 +97,12 @@ def download_table(
     Coerce datetime column and convert to gdf if needed.
     """
     basic_query = basic_sql_query(project_name, dataset_name, table_name)
-    where_condition = add_sql_date_filter(date_col, start_date, end_date)
-    sql_query_statement = f"{basic_query} WHERE {where_condition}"
+    date_condition = add_sql_date_filter(date_col, start_date, end_date)
+
+    if (date_col is None) and (date_condition != ""):
+        sql_query_statement = f"{basic_query} WHERE {date_condition}"
+    if (date_col is None) and (date_condition == ""):
+        sql_query_statement = basic_query
 
     if date_col is None:
         df = pandas_gbq.read_gbq(basic_query, project_id=project_name, dialect="standard", credentials=credentials)
@@ -80,52 +120,61 @@ def download_table(
 
         df = geography_utils.convert_to_gdf(df, geom_col, geom_type)
 
-    return df
-
-
-def download_table_custom_filter(
-    project_name: str = "cal-itp-data-infra",
-    dataset_name: str = "mart_gtfs",
-    table_name: str = "",
-    date_col: Literal["service_date", "month_first_day", None] = "",
-    start_date: str = "",
-    end_date: str = "",
-    columns: list = None,
-    geom_col: str = None,
-    geom_type: Literal["point", "line"] = None,
-    custom_filter_statement: str = "",
-) -> Literal[pd.DataFrame, gpd.GeoDataFrame]:
-    """
-    Set up a basic query and use pandas_gbq to import.
-    Coerce datetime column and convert to gdf if needed.
-    """
-    basic_query = basic_sql_query(project_name, dataset_name, table_name, columns)
-    date_condition = add_sql_date_filter(date_col, start_date, end_date)
-
-    if date_col is None:
-        sql_query_statement = f"{basic_query} WHERE {custom_filter_statement}"
-    if custom_filter_statement != "":
-        sql_query_statement = f"{basic_query} WHERE {date_condition} AND {custom_filter_statement}"
-
-    df = pandas_gbq.read_gbq(
-        sql_query_statement, project_id=project_name, dialect="standard", credentials=credentials
-    ).astype({date_col: "datetime64[ns]"})
-
-    print(f"query: {sql_query_statement}")
-
-    if geom_col is not None:
-
-        df = geography_utils.convert_to_gdf(df, geom_col, geom_type)
+    df = df.pipe(fix_date_columns).pipe(exclude_interval_columns)
 
     return df
 
 
-def bq_faster_download(sql_query: str) -> pd.DataFrame:
-    """ """
-    client = bigquery.Client()
+def bq_faster_download(sql_query: str, **kwargs) -> pd.DataFrame:
+    """
+    This function will take a sql_query string,
+    as well as support parameterized queries.
+    parameterized queries use a job_config kwarg.
+    Use set_bq_query_params() to set this up.
 
-    query_job = client.query(sql_query)
+    docs.cloud.google.com/bigquery/docs/parameterized-queries
+    """
+    client = bigquery.Client(credentials=credentials)
+
+    query_job = client.query(sql_query, **kwargs)
 
     df = query_job.result().to_dataframe()
 
+    df = df.pipe(fix_date_columns).pipe(exclude_interval_columns)
+
     return df
+
+
+def set_bq_query_params(
+    scalar_query_parameter: dict = None,
+    array_query_parameter: dict = None,
+):
+    """
+    Example:
+    scalar_query_parameter = {"gender": "M"}
+    array_query_parameter = {"states": ["WA", "WI", "WV", "WY"]}
+
+
+    Use this function to populate the query_parameters argument.
+    By default, it's an empty list.
+
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("gender", "STRING", "M"),
+            bigquery.ArrayQueryParameter("states", "STRING", ["WA", "WI", "WV", "WY"]),
+        ]
+    )
+    """
+    query_params = []
+
+    if scalar_query_parameter is not None:
+        for column_name, column_value in scalar_query_parameter.items():
+            one_param = bigquery.ScalarQueryParameter(column_name, "STRING", column_value)
+            query_params.append(one_param)
+
+    if array_query_parameter is not None:
+        for column_name, column_list_of_values in array_query_parameter.items():
+            one_param = bigquery.ArrayQueryParameter(column_name, "STRING", column_list_of_values)
+            query_params.append(one_param)
+
+    return query_params

--- a/_gtfs_curator_utils/gtfs_curator_utils/bq_utils.py
+++ b/_gtfs_curator_utils/gtfs_curator_utils/bq_utils.py
@@ -9,7 +9,7 @@ import google.auth
 import pandas as pd
 import pandas_gbq
 from google.cloud import bigquery
-from ridership_utils import geography_utils
+from gtfs_curator_utils import geography_utils
 
 credentials, project = google.auth.default()
 
@@ -99,22 +99,14 @@ def download_table(
     basic_query = basic_sql_query(project_name, dataset_name, table_name)
     date_condition = add_sql_date_filter(date_col, start_date, end_date)
 
-    if (date_col is None) and (date_condition != ""):
+    if date_condition != "":
         sql_query_statement = f"{basic_query} WHERE {date_condition}"
-    if (date_col is None) and (date_condition == ""):
+    if date_condition == "":
         sql_query_statement = basic_query
 
-    if date_col is None:
-        df = pandas_gbq.read_gbq(basic_query, project_id=project_name, dialect="standard", credentials=credentials)
+    df = pandas_gbq.read_gbq(sql_query_statement, project_id=project_name, dialect="standard", credentials=credentials)
 
-        print(f"query: {basic_query}")
-
-    if date_col is not None:
-        df = pandas_gbq.read_gbq(
-            sql_query_statement, project_id=project_name, dialect="standard", credentials=credentials
-        ).astype({date_col: "datetime64[ns]"})
-
-        print(f"query: {sql_query_statement}")
+    print(f"query: {sql_query_statement}")
 
     if geom_col is not None:
 

--- a/gtfs_digest/Makefile
+++ b/gtfs_digest/Makefile
@@ -1,0 +1,12 @@
+digest_report:
+	make gtfs_digest_data
+	#make portfolio_deploy
+
+portfolio_deploy:
+	#python deploy_portfolio_yaml.py
+
+gtfs_digest_data:
+	uv run python _prep_crosswalk_ntd.py
+	uv run python _load_gtfs_data.py
+	#python _prep_gtfs_data.py
+	#python _publish_public_data.py

--- a/gtfs_digest/_load_gtfs_data.py
+++ b/gtfs_digest/_load_gtfs_data.py
@@ -1,0 +1,177 @@
+"""
+Download mart_gtfs_rollup tables for GTFS Digest
+"""
+
+import gcsfs
+import pandas as pd
+from gtfs_curator_utils import bq_utils, utils
+from update_vars import (
+    DIGEST_DICT,
+    PROCESSED_GCS,
+    RAW_GCS,
+    abbrev_month,
+    analysis_month,
+    last_year,
+    previous_month,
+)
+
+crosswalk_url = f"{PROCESSED_GCS}{DIGEST_DICT.crosswalk}_{abbrev_month}.parquet"
+
+
+def load_schedule_rt_route_direction_summary(
+    project_name: str,
+    date_col: str,
+    dataset_name: str,
+    start_date: str,
+    end_date: str,
+) -> pd.DataFrame:
+    df = bq_utils.download_table(
+        project_name=project_name,
+        dataset_name=dataset_name,
+        table_name=DIGEST_DICT.schedule_rt_route_direction,
+        date_col=date_col,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    # Merge with crosswalk
+    crosswalk_df = pd.read_parquet(
+        crosswalk_url, columns=["name", "analysis_name"], filesystem=gcsfs.GCSFileSystem()
+    ).drop_duplicates()
+
+    m1 = pd.merge(df, crosswalk_df, on="name", how="inner")
+
+    utils.geoparquet_gcs_export(m1, f"{RAW_GCS}", f"{DIGEST_DICT.schedule_rt_route_direction}_{abbrev_month}")
+
+    return
+
+
+def load_operator_summary(
+    project_name: str,
+    date_col: str,
+    dataset_name: str,
+    start_date: str,
+    end_date: str,
+) -> pd.DataFrame:
+    df = bq_utils.download_table(
+        project_name=project_name,
+        dataset_name=dataset_name,
+        table_name=DIGEST_DICT.operator_summary,
+        date_col=date_col,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    crosswalk_df = pd.read_parquet(
+        crosswalk_url, columns=["name", "analysis_name", "caltrans_district"], filesystem=gcsfs.GCSFileSystem()
+    ).drop_duplicates()
+
+    m1 = pd.merge(df, crosswalk_df, left_on=["schedule_name"], right_on=["name"], how="inner")
+
+    utils.geoparquet_gcs_export(m1, f"{RAW_GCS}", f"{DIGEST_DICT.operator_summary}_{abbrev_month}")
+
+    return
+
+
+def load_fct_monthly_routes(
+    project_name: str,
+    date_col: str,
+    dataset_name: str,
+    start_date: str,
+    end_date: str,
+) -> pd.DataFrame:
+    gdf = bq_utils.download_table(
+        project_name=project_name,
+        dataset_name=dataset_name,
+        table_name=DIGEST_DICT.route_map,
+        date_col=date_col,
+        start_date=start_date,
+        end_date=end_date,
+        geom_col="pt_array",
+        geom_type="line",
+    )
+
+    crosswalk_df = pd.read_parquet(
+        crosswalk_url, columns=["name", "analysis_name"], filesystem=gcsfs.GCSFileSystem()
+    ).drop_duplicates()
+
+    m1 = pd.merge(gdf, crosswalk_df, on="name", how="inner")
+
+    utils.geoparquet_gcs_export(
+        m1,
+        f"{RAW_GCS}",
+        f"{DIGEST_DICT.route_map}_{abbrev_month}",
+    )
+
+    return
+
+
+def load_fct_operator_hourly_summary(
+    project_name: str,
+    date_col: str,
+    dataset_name: str,
+    start_date: str,
+    end_date: str,
+) -> pd.DataFrame:
+    df = bq_utils.download_table(
+        project_name=project_name,
+        dataset_name=dataset_name,
+        table_name=DIGEST_DICT.hourly_day_type_summary,
+        date_col=date_col,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    # Merge with crosswalk
+    crosswalk_df = pd.read_parquet(
+        crosswalk_url, columns=["name", "analysis_name"], filesystem=gcsfs.GCSFileSystem()
+    ).drop_duplicates()
+
+    m1 = pd.merge(df, crosswalk_df, on="name", how="inner").drop_duplicates().reset_index()
+
+    utils.geoparquet_gcs_export(
+        m1,
+        f"{RAW_GCS}",
+        f"{DIGEST_DICT.hourly_day_type_summary}_{abbrev_month}",
+    )
+
+    return
+
+
+if __name__ == "__main__":
+
+    PROD_PROJECT = "cal-itp-data-infra"
+    PROD_MART = "mart_gtfs_rollup"
+    MONTH_DATE_COL = "month_first_day"
+
+    schedule_rt_route_direction_summary = load_schedule_rt_route_direction_summary(
+        project_name=PROD_PROJECT,
+        date_col=MONTH_DATE_COL,
+        dataset_name=PROD_MART,
+        start_date=last_year,
+        end_date=analysis_month,
+    )
+
+    monthly_operator_summary_df = load_operator_summary(
+        project_name=PROD_PROJECT,
+        date_col=MONTH_DATE_COL,
+        dataset_name=PROD_MART,
+        start_date=last_year,
+        end_date=analysis_month,
+    )
+
+    monthly_routes_gdf = load_fct_monthly_routes(
+        project_name=PROD_PROJECT,
+        date_col=MONTH_DATE_COL,
+        dataset_name=PROD_MART,
+        start_date=previous_month,
+        end_date=analysis_month,
+    )
+
+    fct_operator_hourly_summary = load_fct_operator_hourly_summary(
+        project_name=PROD_PROJECT,
+        date_col=MONTH_DATE_COL,
+        dataset_name=PROD_MART,
+        start_date=last_year,
+        end_date=analysis_month,
+    )

--- a/gtfs_digest/_load_gtfs_data.py
+++ b/gtfs_digest/_load_gtfs_data.py
@@ -144,7 +144,7 @@ if __name__ == "__main__":
     PROD_MART = "mart_gtfs_rollup"
     MONTH_DATE_COL = "month_first_day"
 
-    schedule_rt_route_direction_summary = load_schedule_rt_route_direction_summary(
+    load_schedule_rt_route_direction_summary(
         project_name=PROD_PROJECT,
         date_col=MONTH_DATE_COL,
         dataset_name=PROD_MART,
@@ -152,7 +152,7 @@ if __name__ == "__main__":
         end_date=analysis_month,
     )
 
-    monthly_operator_summary_df = load_operator_summary(
+    load_operator_summary(
         project_name=PROD_PROJECT,
         date_col=MONTH_DATE_COL,
         dataset_name=PROD_MART,
@@ -160,7 +160,7 @@ if __name__ == "__main__":
         end_date=analysis_month,
     )
 
-    monthly_routes_gdf = load_fct_monthly_routes(
+    load_fct_monthly_routes(
         project_name=PROD_PROJECT,
         date_col=MONTH_DATE_COL,
         dataset_name=PROD_MART,
@@ -168,7 +168,7 @@ if __name__ == "__main__":
         end_date=analysis_month,
     )
 
-    fct_operator_hourly_summary = load_fct_operator_hourly_summary(
+    load_fct_operator_hourly_summary(
         project_name=PROD_PROJECT,
         date_col=MONTH_DATE_COL,
         dataset_name=PROD_MART,

--- a/gtfs_digest/_prep_crosswalk_ntd.py
+++ b/gtfs_digest/_prep_crosswalk_ntd.py
@@ -1,0 +1,60 @@
+"""
+Crosswalk
+"""
+
+import gcsfs
+import pandas as pd
+from gtfs_curator_utils import bq_utils
+from update_vars import DIGEST_DICT, PROCESSED_GCS, abbrev_month
+
+
+def load_crosswalk(
+    project_name: str,
+    dataset_name: str,
+    table_name: str = "bridge_gtfs_analysis_name_x_ntd",
+) -> pd.DataFrame:
+    crosswalk_cols = [
+        "schedule_gtfs_dataset_name",
+        "analysis_name",
+        "county_name",
+        "caltrans_district",
+        "caltrans_district_full",
+        "ntd_id",
+        "ntd_id_2022",
+    ]
+
+    df = bq_utils.download_table(
+        project_name=project_name,
+        dataset_name=dataset_name,
+        table_name=table_name,
+        date_col=None,
+        columns=crosswalk_cols,
+    )
+
+    df2 = (
+        df.dropna(subset=["ntd_id", "ntd_id_2022"])
+        .drop_duplicates(subset=["analysis_name", "organization_name", "schedule_gtfs_dataset_name"])
+        .rename(
+            columns={
+                "schedule_gtfs_dataset_name": "name",
+                "caltrans_district": "caltrans_district_int",
+                "caltrans_district_full": "caltrans_district",
+            }
+        )
+        .reset_index(drop=True)
+    )
+
+    df2.to_parquet(f"{PROCESSED_GCS}{DIGEST_DICT.crosswalk}_{abbrev_month}.parquet", filesystem=gcsfs.GCSFileSystem())
+
+    return
+
+
+if __name__ == "__main__":
+
+    PROD_PROJECT = "cal-itp-data-infra"
+    PROD_MART = "mart_transit_database"
+
+    load_crosswalk(
+        project_name=PROD_PROJECT,
+        dataset_name=PROD_MART,
+    )

--- a/gtfs_digest/catalog.yml
+++ b/gtfs_digest/catalog.yml
@@ -1,0 +1,14 @@
+# GTFS Digest Catalog
+gcs_paths:
+  GCS: gs://calitp-analytics-data/data-analyses/
+  DIGEST_GCS: ${.GCS}test_gtfs_digest/
+  PUBLIC_GCS: "gs://calitp-publish-data-analysis/"
+
+gtfs_digest_rollup:
+  dir: ${gcs_paths.DIGEST_GCS}
+  schedule_rt_route_direction: "fct_monthly_schedule_rt_route_direction_summary"
+  route_map: "fct_monthly_routes"
+  operator_summary: "fct_monthly_operator_summary"
+  hourly_day_type_summary: "fct_operator_hourly_summary"
+  ntd_profile: "ntd_profile"
+  crosswalk: "crosswalk"

--- a/gtfs_digest/update_vars.py
+++ b/gtfs_digest/update_vars.py
@@ -1,0 +1,14 @@
+from gtfs_curator_utils import catalog_utils
+
+CATALOG_DICT = catalog_utils.get_catalog("catalog.yml", use_intake=False)
+DIGEST_DICT = CATALOG_DICT.gtfs_digest_rollup
+
+analysis_month = "2026-01-01"
+last_year = "2025-01-01"
+previous_month = "2025-12-01"
+
+abbrev_month = analysis_month.replace("-", "_")[0:7]
+
+DIGEST_GCS = DIGEST_DICT.dir
+RAW_GCS = f"{DIGEST_GCS}raw/"
+PROCESSED_GCS = f"{DIGEST_GCS}processed/"


### PR DESCRIPTION
With new `uv` set up and much fewer dependencies, bring over existing GTFS Digest scripts that download from warehouse and make sure they run.  

Test out NTD scripts for downloading to nail down `bq_utils`.

- Progress towards #33
- [x] pare down dependencies in this repo, and make sure existing GTFS Digest scripts work
- [x] set up Makefile
- [x] streamline shared variables and references
- [x] move contents needed for `gtfs_analytics_data.yml` into `catalog.yml`