### PR TITLE
Exploratory work for `fct_vehicle_locations` experimental columns 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ add_precommit:
 	pre-commit install
 	#pre-commit run --all-files
 
-install_env:
+install_env_pip:
 	cd _gtfs_curator_utils/ && pip install -r requirements.txt && cd ../
 	make add_precommit
 
-install_env_uv:
+install_env:
 	pip install uv && uv sync --all-groups
 	make add_precommit
 

--- a/rt_vehicle_positions/01_vp_stop_exploratory.ipynb
+++ b/rt_vehicle_positions/01_vp_stop_exploratory.ipynb
@@ -1,0 +1,1996 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f11a2575-31f2-404d-a468-4f92562216d9",
+   "metadata": {},
+   "source": [
+    "# Usable Stop Metrics\n",
+    "\n",
+    "There are several experimental columns that should tell us more about how vehicle positions relate to stops for that trip. How complete are these columns in `fct_vehicle_locations`?\n",
+    "* Take `fct_vehicle_locations` -> aggregated to `trip_instance_key-stop_id-current_stop_sequence`\n",
+    "* We'd want to use potentially both `stop_id` and `current_stop_sequence` to understand whether the vp is at / in transit to a stop to better figure out when the bus has arrived at a stop, when is it dwelling, etc.\n",
+    "\n",
+    "**Findings**\n",
+    "* Overall, not much is useful by stop, so let's retain all these experimental columns as arrays for `fct_vehicle_positions_trip_metrics`. Keep all the raw values.\n",
+    "* Also, add counts / distinct values for these experiemental columns. Be able to quickly take a pulse, see if the experimental columns are increasingly getting populated (through our outreach or operator provides it)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b2028f08-53b5-47dd-af53-028ad14f6b78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gcsfs\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "VP_GCS = \"gs://calitp-analytics-data/data-analyses/rt_vehicle_positions/\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cd4f6ae-4969-4471-8698-3f82108c5926",
+   "metadata": {},
+   "source": [
+    "## Data Prep\n",
+    "Merge in scheduled trips and get a better overview by `service_date-route_id-direction_id`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d4712d2c-3852-424a-a7c2-1650e21a5bc6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def clean_up_stop_metrics(df):\n",
+    "    \"\"\"\n",
+    "    Catch stuff that should be part of the SQL\n",
+    "    \"\"\"\n",
+    "    df = df.rename(\n",
+    "        columns = {\"f0_\": \"congestion_level_array\"}\n",
+    "    )\n",
+    "    return df\n",
+    "\n",
+    "stop = pd.read_parquet(\n",
+    "    f\"{VP_GCS}vp_stop_metrics.parquet\",\n",
+    "    filesystem = gcsfs.GCSFileSystem(),\n",
+    "    #filters = [[(\"gtfs_dataset_name\", \"==\", \"LA Metro Bus Vehicle Positions\")]]\n",
+    ").pipe(clean_up_stop_metrics)\n",
+    "\n",
+    "trips = pd.read_parquet(\n",
+    "    f\"{VP_GCS}scheduled_trips.parquet\",\n",
+    "    filesystem = gcsfs.GCSFileSystem(),\n",
+    "    columns = [\"trip_instance_key\", \"route_id\", \"direction_id\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ebc718e4-eff9-4806-9654-0ed0e4b42f3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.merge(\n",
+    "    stop,\n",
+    "    trips,\n",
+    "    on = \"trip_instance_key\",\n",
+    "    how = \"inner\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "25a4fb5b-b27f-46a6-88d9-24514af656b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trip_cols = [\n",
+    "    \"gtfs_dataset_name\", \"service_date\", \n",
+    "    \"route_id\", \"direction_id\", \n",
+    "    \"trip_instance_key\", \n",
+    "]\n",
+    "\n",
+    "stop_cols = [\"stop_id\", \"current_stop_sequence\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34e3c365-85a9-4417-998b-e87f8d01902d",
+   "metadata": {},
+   "source": [
+    "### `current_status` and number of stops per trip captured \n",
+    "\n",
+    "Values: `in_transit_to`, `stopped_at`, `incoming_at`.\n",
+    "\n",
+    "1. How many are null vs populated? Is this operator-specific or are nulls randomly distributed throughout?\n",
+    "2. Within those that are populated, does this match the number of stops that are being visited for that trip? `nunique(stop_id) <= nunique(current_stop_sequence)` or fairly close, because `stop_id` is allowed to repeat for a trip, especially if it loops back around.\n",
+    "3. If `current_status` is well populated, can we use `stopped_at` to find out when bus has arrived at a stop? If this tells us enough, we don't have to use trip updates to determine actual arrival. This would sit at a closer source (vp) to use for speedmaps.\n",
+    "\n",
+    "**Exploratory Notes**\n",
+    "\n",
+    "* Distribution of `current_status` is that nearly half is `IN_TRANSIT_TO`, 1/3 is `STOPPED_AT`. Very few are missing. This is promising.\n",
+    "   * Check whether every `stop_id` or `current_stop_sequence` shows up with `current_status`.\n",
+    "* Count unique stops (stop_id, stop_sequence) present in the vehicle_locations_df. Compare that how many stops show up with `current_status='STOPPED_AT'`.\n",
+    "   * Can we use `STOPPED_AT` to find when it arrived at a stop?\n",
+    "   * Aggregate this to trip (if trip serves 10 stops, how many of these 10 have `current_status=STOPPED_AT`)?\n",
+    "   * Aggregate to route-direction to see whether we have \"complete\" coverage of `current_status=STOPPED_AT` information within vehicle_locations_df. If trip is missing quite a bit, do we get enough coverage by route?\n",
+    "\n",
+    "**Findings**\n",
+    "We're missing a lot, then this column isn't that usable now. \n",
+    "* Significant variation in how good the coverage is.\n",
+    "* By route, we are missing quite a bit of stops, enough to not use it.\n",
+    "* By operators, some have min values that are negative. This just means we have to dedupe, because there are more rows with `STOPPED_AT` than we have unique stop_id / stop_sequence.\n",
+    "\n",
+    "If we want to track how good that coverage is, we can add this to trip-level summary to get unique stop_id, stop_sequence, as well as non-null counts of `current_status`...and how many stop_ids or stop_sequence shows up with `current_status=STOPPED_AT`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5aad6af4-8662-4c61-9599-fdc87314c4de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def stop_current_status_counts(df: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Get counts of stop_id, current_stop_sequence, current_status for each trip.\n",
+    "    \n",
+    "    Visualize how trips are populated by operator-route_id-direction_id.\n",
+    "    \"\"\"\n",
+    "    trip_cols = [\n",
+    "        \"gtfs_dataset_name\", \"service_date\", \n",
+    "        \"route_id\", \"direction_id\", \n",
+    "        \"trip_instance_key\", \n",
+    "    ]\n",
+    "    \n",
+    "    current_status_pivoted_by_trip = df.pivot_table(\n",
+    "        index=trip_cols, \n",
+    "        columns='current_status', \n",
+    "        fill_value=0, \n",
+    "        aggfunc='size'\n",
+    "    ).reset_index()\n",
+    "       \n",
+    "    counts_by_trip = (\n",
+    "        df\n",
+    "        .groupby(trip_cols, dropna=False)\n",
+    "        .agg({\n",
+    "            \"stop_id\": \"nunique\",\n",
+    "            \"current_stop_sequence\": \"nunique\",\n",
+    "        })\n",
+    "        .reset_index()\n",
+    "        .rename(columns = {\n",
+    "            \"stop_id\": \"nunique_stop_id\", \n",
+    "            \"current_stop_sequence\": \"nunique_stop_seq\"\n",
+    "        })\n",
+    "    )\n",
+    "\n",
+    "    df2 = pd.merge(\n",
+    "        counts_by_trip,\n",
+    "        current_status_pivoted_by_trip,\n",
+    "        on = trip_cols,\n",
+    "        how = \"inner\"\n",
+    "    )\n",
+    "\n",
+    "    df2 = df2.assign(\n",
+    "        status_shortage = df2[[\"nunique_stop_id\", \"nunique_stop_seq\"]].min(axis=1) - df2.STOPPED_AT\n",
+    "    )\n",
+    "    \n",
+    "    return df2\n",
+    "\n",
+    "\n",
+    "def usable_status_by_route(df: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    \"\"\"\n",
+    "    route_cols = [\"service_date\", \"gtfs_dataset_name\", \"route_id\"]\n",
+    "    counts_by_route = (\n",
+    "        df\n",
+    "        .groupby(route_cols, dropna=False)\n",
+    "        .agg({\n",
+    "            \"trip_instance_key\": \"nunique\",\n",
+    "            \"status_shortage\": \"mean\"}\n",
+    "        ).reset_index()\n",
+    "    )\n",
+    "\n",
+    "    total_shortage_by_route = (\n",
+    "        df\n",
+    "        .groupby(route_cols, dropna=False)\n",
+    "        .agg({\n",
+    "            \"status_shortage\": \"sum\"}\n",
+    "        ).reset_index()\n",
+    "    )\n",
+    "\n",
+    "    df2 = pd.merge(\n",
+    "        counts_by_route.rename(\n",
+    "            columns = {\n",
+    "                \"status_shortage\": \"avg_stops_status_shortage\", \n",
+    "                \"trip_instance_key\": \"n_trips\"\n",
+    "            }),\n",
+    "        total_shortage_by_route.rename(columns = {\"status_shortage\": \"total_stops_status_shortage\"}),\n",
+    "        on = route_cols,\n",
+    "        how = \"inner\"\n",
+    "    )\n",
+    "\n",
+    "    return df2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c6e5df8b-cae3-4b90-8900-43e51d21e2ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "current_status\n",
+       "IN_TRANSIT_TO    1015041\n",
+       "STOPPED_AT        807274\n",
+       "INCOMING_AT       329325\n",
+       "None               45302\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.current_status.value_counts(dropna=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1584f1da-9953-4e83-a1d5-e0e09d90e135",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "current_status\n",
+       "IN_TRANSIT_TO    0.462024\n",
+       "STOPPED_AT       0.367453\n",
+       "INCOMING_AT      0.149902\n",
+       "None             0.020620\n",
+       "Name: proportion, dtype: float64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.current_status.value_counts(dropna=False, normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "16f29d83-6680-4150-8710-55e8dd5a8387",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>gtfs_dataset_name</th>\n",
+       "      <th>service_date</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>direction_id</th>\n",
+       "      <th>trip_instance_key</th>\n",
+       "      <th>stop_id</th>\n",
+       "      <th>current_stop_sequence</th>\n",
+       "      <th>current_status</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1103018</th>\n",
+       "      <td>Bay Area 511 AC Transit Vehicle Position</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>57</td>\n",
+       "      <td>0</td>\n",
+       "      <td>fefed2b09320447a963f73e49d3513dd</td>\n",
+       "      <td>51375</td>\n",
+       "      <td>23</td>\n",
+       "      <td>IN_TRANSIT_TO</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1065853</th>\n",
+       "      <td>Bay Area 511 SamTrans VehiclePositions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>ECR</td>\n",
+       "      <td>0</td>\n",
+       "      <td>14f150a04c1ec0d4ba7d2fc7aed0e32e</td>\n",
+       "      <td>336028</td>\n",
+       "      <td>55</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1748009</th>\n",
+       "      <td>LA Metro Bus Vehicle Positions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>224-13196</td>\n",
+       "      <td>1</td>\n",
+       "      <td>476f91ff35650a2e677d68411dbea1dd</td>\n",
+       "      <td>2838</td>\n",
+       "      <td>53</td>\n",
+       "      <td>IN_TRANSIT_TO</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2123394</th>\n",
+       "      <td>LA Metro Bus Vehicle Positions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>70-13196</td>\n",
+       "      <td>1</td>\n",
+       "      <td>bf8c18c0d97e9bf7ccd613db99b131d8</td>\n",
+       "      <td>9997</td>\n",
+       "      <td>11</td>\n",
+       "      <td>IN_TRANSIT_TO</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>718666</th>\n",
+       "      <td>Bay Area 511 AC Transit Vehicle Position</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>840</td>\n",
+       "      <td>1</td>\n",
+       "      <td>f21993e33da6d1ae95cc32aab5c0b918</td>\n",
+       "      <td>51548</td>\n",
+       "      <td>6</td>\n",
+       "      <td>INCOMING_AT</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                gtfs_dataset_name service_date   route_id  \\\n",
+       "1103018  Bay Area 511 AC Transit Vehicle Position   2026-01-01         57   \n",
+       "1065853    Bay Area 511 SamTrans VehiclePositions   2026-01-01        ECR   \n",
+       "1748009            LA Metro Bus Vehicle Positions   2026-01-01  224-13196   \n",
+       "2123394            LA Metro Bus Vehicle Positions   2026-01-01   70-13196   \n",
+       "718666   Bay Area 511 AC Transit Vehicle Position   2026-01-01        840   \n",
+       "\n",
+       "         direction_id                 trip_instance_key stop_id  \\\n",
+       "1103018             0  fefed2b09320447a963f73e49d3513dd   51375   \n",
+       "1065853             0  14f150a04c1ec0d4ba7d2fc7aed0e32e  336028   \n",
+       "1748009             1  476f91ff35650a2e677d68411dbea1dd    2838   \n",
+       "2123394             1  bf8c18c0d97e9bf7ccd613db99b131d8    9997   \n",
+       "718666              1  f21993e33da6d1ae95cc32aab5c0b918   51548   \n",
+       "\n",
+       "         current_stop_sequence current_status  \n",
+       "1103018                     23  IN_TRANSIT_TO  \n",
+       "1065853                     55           None  \n",
+       "1748009                     53  IN_TRANSIT_TO  \n",
+       "2123394                     11  IN_TRANSIT_TO  \n",
+       "718666                       6    INCOMING_AT  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cols_to_look_at = [\"current_status\"]\n",
+    "df[trip_cols + stop_cols + cols_to_look_at].sample(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "dd8aace1-6c0d-4de5-bc4d-1de9925537db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "usable_status = stop_current_status_counts(df)\n",
+    "route_status = usable_status_by_route(usable_status)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e4d0774a-8479-4ea1-9d7f-4001203e74e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>service_date</th>\n",
+       "      <th>gtfs_dataset_name</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>n_trips</th>\n",
+       "      <th>avg_stops_status_shortage</th>\n",
+       "      <th>total_stops_status_shortage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>161</th>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>Bay Area 511 SamTrans VehiclePositions</td>\n",
+       "      <td>ECR</td>\n",
+       "      <td>126</td>\n",
+       "      <td>70.388889</td>\n",
+       "      <td>8869</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>202</th>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>Bay Area 511 Tri Delta VehiclePositions</td>\n",
+       "      <td>373</td>\n",
+       "      <td>32</td>\n",
+       "      <td>-6.625000</td>\n",
+       "      <td>-212</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>205</th>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>Bay Area 511 Tri Delta VehiclePositions</td>\n",
+       "      <td>376</td>\n",
+       "      <td>30</td>\n",
+       "      <td>-3.866667</td>\n",
+       "      <td>-116</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>234</th>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>Foothill Vehicle Positions</td>\n",
+       "      <td>10492</td>\n",
+       "      <td>51</td>\n",
+       "      <td>21.803922</td>\n",
+       "      <td>1112</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>420</th>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>Redding Vehicle Positions</td>\n",
+       "      <td>24</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>293</th>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>LA Metro Bus Vehicle Positions</td>\n",
+       "      <td>204-13196</td>\n",
+       "      <td>172</td>\n",
+       "      <td>11.220930</td>\n",
+       "      <td>1930</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>Bay Area 511 AC Transit Vehicle Position</td>\n",
+       "      <td>34</td>\n",
+       "      <td>34</td>\n",
+       "      <td>42.735294</td>\n",
+       "      <td>1453</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>166</th>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>Bay Area 511 Santa Clara Transit VehiclePositions</td>\n",
+       "      <td>203</td>\n",
+       "      <td>2</td>\n",
+       "      <td>11.000000</td>\n",
+       "      <td>22</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>237</th>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>Foothill Vehicle Positions</td>\n",
+       "      <td>20187</td>\n",
+       "      <td>64</td>\n",
+       "      <td>18.593750</td>\n",
+       "      <td>1190</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>453</th>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>SCVTA Swiftly Vehicle Position</td>\n",
+       "      <td>85</td>\n",
+       "      <td>19</td>\n",
+       "      <td>10.421053</td>\n",
+       "      <td>198</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    service_date                                  gtfs_dataset_name  \\\n",
+       "161   2026-01-01             Bay Area 511 SamTrans VehiclePositions   \n",
+       "202   2026-01-01            Bay Area 511 Tri Delta VehiclePositions   \n",
+       "205   2026-01-01            Bay Area 511 Tri Delta VehiclePositions   \n",
+       "234   2026-01-01                         Foothill Vehicle Positions   \n",
+       "420   2026-01-01                          Redding Vehicle Positions   \n",
+       "293   2026-01-01                     LA Metro Bus Vehicle Positions   \n",
+       "18    2026-01-01           Bay Area 511 AC Transit Vehicle Position   \n",
+       "166   2026-01-01  Bay Area 511 Santa Clara Transit VehiclePositions   \n",
+       "237   2026-01-01                         Foothill Vehicle Positions   \n",
+       "453   2026-01-01                     SCVTA Swiftly Vehicle Position   \n",
+       "\n",
+       "      route_id  n_trips  avg_stops_status_shortage  \\\n",
+       "161        ECR      126                  70.388889   \n",
+       "202        373       32                  -6.625000   \n",
+       "205        376       30                  -3.866667   \n",
+       "234      10492       51                  21.803922   \n",
+       "420         24        4                   1.000000   \n",
+       "293  204-13196      172                  11.220930   \n",
+       "18          34       34                  42.735294   \n",
+       "166        203        2                  11.000000   \n",
+       "237      20187       64                  18.593750   \n",
+       "453         85       19                  10.421053   \n",
+       "\n",
+       "     total_stops_status_shortage  \n",
+       "161                         8869  \n",
+       "202                         -212  \n",
+       "205                         -116  \n",
+       "234                         1112  \n",
+       "420                            4  \n",
+       "293                         1930  \n",
+       "18                          1453  \n",
+       "166                           22  \n",
+       "237                         1190  \n",
+       "453                          198  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "route_status.sample(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "33e60370-9526-43f2-95eb-659c5b7ac56b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>gtfs_dataset_name</th>\n",
+       "      <th>service_date</th>\n",
+       "      <th colspan=\"3\" halign=\"left\">avg_stops_status_shortage</th>\n",
+       "      <th colspan=\"3\" halign=\"left\">total_stops_status_shortage</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>min</th>\n",
+       "      <th>mean</th>\n",
+       "      <th>max</th>\n",
+       "      <th>min</th>\n",
+       "      <th>mean</th>\n",
+       "      <th>max</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>Mendocino Vehicle Positions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>4.500000</td>\n",
+       "      <td>4.500000</td>\n",
+       "      <td>4.500000</td>\n",
+       "      <td>9</td>\n",
+       "      <td>9.000000</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>LA Metro Rail Vehicle Positions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>1.019608</td>\n",
+       "      <td>3.493036</td>\n",
+       "      <td>9.703057</td>\n",
+       "      <td>208</td>\n",
+       "      <td>739.166667</td>\n",
+       "      <td>2222</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>LA Metro Bus Vehicle Positions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>2.254717</td>\n",
+       "      <td>16.405106</td>\n",
+       "      <td>46.230769</td>\n",
+       "      <td>92</td>\n",
+       "      <td>1388.165049</td>\n",
+       "      <td>3980</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Bay Area 511 Marin VehiclePositions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>3.564706</td>\n",
+       "      <td>8.657776</td>\n",
+       "      <td>14.291667</td>\n",
+       "      <td>127</td>\n",
+       "      <td>247.142857</td>\n",
+       "      <td>411</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Bay Area 511 SamTrans VehiclePositions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>0.666667</td>\n",
+       "      <td>27.600363</td>\n",
+       "      <td>91.000000</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1323.384615</td>\n",
+       "      <td>8869</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Bay Area 511 Golden Gate Transit Vehicle Posit...</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>-13.594595</td>\n",
+       "      <td>-9.117735</td>\n",
+       "      <td>-2.709677</td>\n",
+       "      <td>-503</td>\n",
+       "      <td>-296.750000</td>\n",
+       "      <td>-84</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Bay Area 511 AC Transit Vehicle Position</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>12.481132</td>\n",
+       "      <td>34.652611</td>\n",
+       "      <td>69.538462</td>\n",
+       "      <td>239</td>\n",
+       "      <td>2242.216667</td>\n",
+       "      <td>7720</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>SCVTA Swiftly Vehicle Position</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>1.737374</td>\n",
+       "      <td>16.524397</td>\n",
+       "      <td>42.915789</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1019.500000</td>\n",
+       "      <td>4861</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Bay Area 511 Santa Clara Transit VehiclePositions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>1.818182</td>\n",
+       "      <td>16.189640</td>\n",
+       "      <td>41.600000</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1001.277778</td>\n",
+       "      <td>4755</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>Redding Vehicle Positions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>4</td>\n",
+       "      <td>4.000000</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                    gtfs_dataset_name service_date  \\\n",
+       "                                                                     \n",
+       "15                        Mendocino Vehicle Positions   2026-01-01   \n",
+       "13                    LA Metro Rail Vehicle Positions   2026-01-01   \n",
+       "12                     LA Metro Bus Vehicle Positions   2026-01-01   \n",
+       "3                 Bay Area 511 Marin VehiclePositions   2026-01-01   \n",
+       "5              Bay Area 511 SamTrans VehiclePositions   2026-01-01   \n",
+       "2   Bay Area 511 Golden Gate Transit Vehicle Posit...   2026-01-01   \n",
+       "0            Bay Area 511 AC Transit Vehicle Position   2026-01-01   \n",
+       "19                     SCVTA Swiftly Vehicle Position   2026-01-01   \n",
+       "6   Bay Area 511 Santa Clara Transit VehiclePositions   2026-01-01   \n",
+       "18                          Redding Vehicle Positions   2026-01-01   \n",
+       "\n",
+       "   avg_stops_status_shortage                        \\\n",
+       "                         min       mean        max   \n",
+       "15                  4.500000   4.500000   4.500000   \n",
+       "13                  1.019608   3.493036   9.703057   \n",
+       "12                  2.254717  16.405106  46.230769   \n",
+       "3                   3.564706   8.657776  14.291667   \n",
+       "5                   0.666667  27.600363  91.000000   \n",
+       "2                 -13.594595  -9.117735  -2.709677   \n",
+       "0                  12.481132  34.652611  69.538462   \n",
+       "19                  1.737374  16.524397  42.915789   \n",
+       "6                   1.818182  16.189640  41.600000   \n",
+       "18                  1.000000   1.000000   1.000000   \n",
+       "\n",
+       "   total_stops_status_shortage                     \n",
+       "                           min         mean   max  \n",
+       "15                           9     9.000000     9  \n",
+       "13                         208   739.166667  2222  \n",
+       "12                          92  1388.165049  3980  \n",
+       "3                          127   247.142857   411  \n",
+       "5                            4  1323.384615  8869  \n",
+       "2                         -503  -296.750000   -84  \n",
+       "0                          239  2242.216667  7720  \n",
+       "19                           3  1019.500000  4861  \n",
+       "6                            3  1001.277778  4755  \n",
+       "18                           4     4.000000     4  "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "route_status.groupby([\"gtfs_dataset_name\", \"service_date\"]).agg({\n",
+    "    \"avg_stops_status_shortage\": [\"min\", \"mean\", \"max\"],\n",
+    "    \"total_stops_status_shortage\": [\"min\", \"mean\", \"max\"]\n",
+    "}).reset_index().sample(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34119236-5b4e-47e5-b3f8-dddf7635740a",
+   "metadata": {},
+   "source": [
+    "### congestion_level\n",
+    "Values: `congestion_level_array`\n",
+    "\n",
+    "1. Not clear from GTFS RT spec whether this is populated for every vehicle position or for the trip? Does it get updated when the congestion changes as the trip progresses?\n",
+    "\n",
+    "   * It seems to be **by trip**, as within a trip, there is only 1 distinct value.\n",
+    "   * Although, maybe the default is set to `UNKNOWN_CONGESTION_LEVEL`, so there's not enough variation to tell. \n",
+    "\n",
+    "2. How many are null vs populated? Is this operator-specific or are nulls randomly distributed throughout?\n",
+    "   * Most of these are null or `UNKNOWN_CONGESTION_LEVEL`, so there's not much that's usable across all the operators here.\n",
+    "  \n",
+    "**Findings**\n",
+    "* It probably is set by trip, though we don't have enough variation to tell. \n",
+    "* Most of these are null or `UNKNOWN_CONGESTION_LEVEL`, so there's not much that's usable across all the operators here.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "456c06cd-b667-47fe-ae18-c0fb1eaa3d59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trip_cols = [\n",
+    "    \"gtfs_dataset_name\", \"service_date\", \n",
+    "    \"route_id\", \"direction_id\", \n",
+    "    \"trip_instance_key\", \n",
+    "]\n",
+    "\n",
+    "stop_cols = [\"stop_id\", \"current_stop_sequence\"]\n",
+    "cols_to_look_at = [\"congestion_level_array\", \"count_congestion_level\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "5eb70fe1-fff4-4550-9d09-6974145238e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count_congestion_level\n",
+       "0      2110388\n",
+       "1        59366\n",
+       "2        13335\n",
+       "3         4360\n",
+       "4         2393\n",
+       "        ...   \n",
+       "169          1\n",
+       "93           1\n",
+       "192          1\n",
+       "124          1\n",
+       "167          1\n",
+       "Name: count, Length: 162, dtype: Int64"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[trip_cols + stop_cols + cols_to_look_at].count_congestion_level.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "f29d4a85-8193-42c0-aefd-f7f986d8c6c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count_congestion_level\n",
+       "0      0.960603\n",
+       "1      0.027022\n",
+       "2       0.00607\n",
+       "3      0.001985\n",
+       "4      0.001089\n",
+       "         ...   \n",
+       "169         0.0\n",
+       "93          0.0\n",
+       "192         0.0\n",
+       "124         0.0\n",
+       "167         0.0\n",
+       "Name: proportion, Length: 162, dtype: Float64"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[trip_cols + stop_cols + cols_to_look_at].count_congestion_level.value_counts(normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ad593030-2224-46b2-88fd-5430585129c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Figure out whether congestion_level_array is by vehicle or by trip or by stop\n",
+    "def aggregate_array_by_group(df: pd.DataFrame, group_cols: list, array_col: str) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Groupby and combine the possible values in array.\n",
+    "    Get distinct values (np.unique), flatten the nested array into 1 single array \n",
+    "    (np.concatenate for combining, ravel for flattening),\n",
+    "    and turn result into a list (.tolist()) instead of array.\n",
+    "    \n",
+    "    Replicate what Big Query ARRAY_AGG would do, but we aren't sorting here.\n",
+    "    \"\"\"\n",
+    "    df2 = (\n",
+    "        df\n",
+    "        .groupby(group_cols, dropna=False)\n",
+    "        .agg({\n",
+    "            array_col: lambda x: np.unique(np.concatenate(np.asarray(x)).ravel()).tolist()\n",
+    "        })\n",
+    "        .reset_index()\n",
+    "    )\n",
+    "\n",
+    "    # See how many distinct values were filled in\n",
+    "    # If unknown is filled in, tag a dummy\n",
+    "    df2 = df2.assign(\n",
+    "        distinct_array_values = df2.apply(lambda x: len(x[array_col]), axis=1),\n",
+    "        is_unknown = df2.apply(lambda x: \"UNKNOWN_CONGESTION_LEVEL\" in x[array_col], axis=1),\n",
+    "        is_zero = df2.apply(lambda x: 0 in x[array_col], axis=1),\n",
+    "    )\n",
+    "\n",
+    "    return df2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "b61b3753-8c3d-41c6-9cb9-679c78910211",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "distinct_array_values\n",
+       "0    1360067\n",
+       "1      60939\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# For a trip-stop, check whether there are different congestion_levels\n",
+    "# No, at most there is just 1 distinct value. It's all nulls or unknown.\n",
+    "congestion_by_stop = aggregate_array_by_group(df, trip_cols + stop_cols, \"congestion_level_array\")\n",
+    "congestion_by_stop.distinct_array_values.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e5a59d21-79c4-4932-a1fb-833fad7f2fa5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "is_unknown\n",
+       "True    60939\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "congestion_by_stop[congestion_by_stop.distinct_array_values == 1].is_unknown.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "9b00bbf6-e420-4ef8-b1f0-85829e8bb1e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "distinct_array_values\n",
+       "0    38708\n",
+       "1     1459\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Repeat this for trip, if there are still just 1 distinct value per trip, then congestion_level is likely set per trip.\n",
+    "congestion_by_trip = aggregate_array_by_group(df, trip_cols, \"congestion_level_array\")\n",
+    "congestion_by_trip.distinct_array_values.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "307c8ae6-cc90-4848-87e1-b0d6667df357",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "is_unknown\n",
+       "True    1459\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "congestion_by_trip[congestion_by_trip.distinct_array_values == 1].is_unknown.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d51e6583-50fe-4d73-81ea-5842703841b1",
+   "metadata": {},
+   "source": [
+    "### occupancy\n",
+    "\n",
+    "Values: `occupancy_status`, `occupancy_percentage`\n",
+    "\n",
+    "1. Not clear from the GTFS RT spec whether this is populated for every stop or vehicle position?\n",
+    "2. How many are null vs populated? Is this operator-specific or are nulls randomly distributed throughout?\n",
+    "3. If this is populated for stop or every vehicle position, what would be a meaningful metric? Occupancy at the stop to understand which stops are popular? Occupancy for the trip to understand ridership?\n",
+    "\n",
+    "**Findings**\n",
+    "* still not clear whether this is populated for every stop, position, or trip. But, looking per trip, majority (90%+) is zero distinct values, which means it's\n",
+    "* by stop, about 85% of the values will have 0, 1, or 2 values filled in. so this is definitely not useful by stop or position. stop is granular of a row and `occupancy_status` isn't showing variation at that granularity (or finer granularity).\n",
+    "* by trip, Fresno, Long Beach provide some information here, but when you look at the stop information, it's null\n",
+    "* maybe add count of non-null and distinct values for trip, and if these columns are increasingly populated, we'll have a way to flag it. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "8bfe175f-903a-4972-9782-da342c273fc8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cols_to_look_at = [\"count_occupancy_status\", \"occupancy_percentage_array\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "c96615ec-7485-4631-a6b8-77e180a7b052",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count_occupancy_status\n",
+       "0       996668\n",
+       "1       569875\n",
+       "2       293865\n",
+       "3       151069\n",
+       "4        59016\n",
+       "         ...  \n",
+       "316          1\n",
+       "417          1\n",
+       "651          1\n",
+       "1098         1\n",
+       "466          1\n",
+       "Name: count, Length: 413, dtype: Int64"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[trip_cols + stop_cols + cols_to_look_at].count_occupancy_status.value_counts(dropna=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "954a1ff6-1829-43be-b68e-effcc7e2a72d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count_occupancy_status\n",
+       "0       0.453661\n",
+       "1       0.259395\n",
+       "2       0.133761\n",
+       "3       0.068763\n",
+       "4       0.026863\n",
+       "          ...   \n",
+       "316          0.0\n",
+       "417          0.0\n",
+       "651          0.0\n",
+       "1098         0.0\n",
+       "466          0.0\n",
+       "Name: proportion, Length: 413, dtype: Float64"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# about 85% of the values will have 0, 1, or 2 values filled in\n",
+    "df[trip_cols + stop_cols + cols_to_look_at].count_occupancy_status.value_counts(dropna=False, normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "1aedb13b-3f78-40ba-96e7-f1842d7df670",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "distinct_array_values\n",
+       "0    1299951\n",
+       "1     120921\n",
+       "2        121\n",
+       "3         13\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Take a look at the distinct values\n",
+    "occupancy_by_stop = aggregate_array_by_group(df, trip_cols + stop_cols, \"occupancy_percentage_array\")\n",
+    "occupancy_by_stop.distinct_array_values.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "e8efcdd0-d185-499d-af13-187666ae36ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "distinct_array_values\n",
+       "0    0.914810\n",
+       "1    0.085095\n",
+       "2    0.000085\n",
+       "3    0.000009\n",
+       "Name: proportion, dtype: float64"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "occupancy_by_stop.distinct_array_values.value_counts(normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "2e1ec6dd-6c0f-4bbd-9c2e-3bee2aef9361",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "is_zero\n",
+       "True     120253\n",
+       "False       802\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "occupancy_by_stop[occupancy_by_stop.distinct_array_values > 0].is_zero.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "b8cb589c-9d9d-49e6-949d-38aad10ad8b6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "gtfs_dataset_name\n",
+       "Fresno Vehicle Positions       73\n",
+       "Long Beach VehiclePositions    61\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Fresno, Long Beach provide some information here\n",
+    "occupancy_by_stop[(occupancy_by_stop.distinct_array_values > 1) & \n",
+    "    (occupancy_by_stop.is_zero==False)].gtfs_dataset_name.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "6e0c30ea-beb0-40b5-9f20-320649f7bf8d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>gtfs_dataset_name</th>\n",
+       "      <th>trip_instance_key</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>direction_id</th>\n",
+       "      <th>stop_id</th>\n",
+       "      <th>current_stop_sequence</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [gtfs_dataset_name, trip_instance_key, route_id, direction_id, stop_id, current_stop_sequence]\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Since it's already differing by stop, does it change from stop to stop?\n",
+    "# stop_id and current_stop_seq are nulls for where this is happening\n",
+    "occupancy_by_stop[\n",
+    "    (occupancy_by_stop.gtfs_dataset_name.isin([\"Fresno Vehicle Positions\", \"Long Beach VehiclePositions\"])) &\n",
+    "    (occupancy_by_stop.distinct_array_values > 1) &\n",
+    "    (occupancy_by_stop.is_zero==False)\n",
+    "][[\"gtfs_dataset_name\", \"trip_instance_key\", \n",
+    "   \"route_id\", \"direction_id\", \n",
+    "   \"stop_id\", \"current_stop_sequence\"\n",
+    "  ]].drop_duplicates().dropna(subset=[\"stop_id\", \"current_stop_sequence\"]).sort_values([\"trip_instance_key\", \"current_stop_sequence\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "4a234a5b-f50c-434d-a21a-24ccb26155d3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "distinct_array_values\n",
+       "0    37442\n",
+       "1     2591\n",
+       "2      121\n",
+       "3       13\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Take a look at the distinct values by trip, maybe it's differing here?\n",
+    "occupancy_by_trip = aggregate_array_by_group(df, trip_cols, \"occupancy_percentage_array\")\n",
+    "occupancy_by_trip.distinct_array_values.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "431eed2e-7f38-448c-ba8d-b1b6e908c1d3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "is_zero\n",
+       "True     1923\n",
+       "False     802\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "occupancy_by_trip[occupancy_by_trip.distinct_array_values > 0].is_zero.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "69b19ae8-49a9-413b-a109-13f90a22bbc3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>gtfs_dataset_name</th>\n",
+       "      <th>trip_instance_key</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>direction_id</th>\n",
+       "      <th>occupancy_percentage_array</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>30184</th>\n",
+       "      <td>Long Beach VehiclePositions</td>\n",
+       "      <td>25e1d510b95ab5fddd45546b91701f44</td>\n",
+       "      <td>111</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[100, 120]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30192</th>\n",
+       "      <td>Long Beach VehiclePositions</td>\n",
+       "      <td>c3b492eb6f7a0548a5579b04405f7a39</td>\n",
+       "      <td>111</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[100, 120]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30198</th>\n",
+       "      <td>Long Beach VehiclePositions</td>\n",
+       "      <td>1061aea0c07107fc014beb06f10aae31</td>\n",
+       "      <td>111</td>\n",
+       "      <td>1</td>\n",
+       "      <td>[100, 120]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30205</th>\n",
+       "      <td>Long Beach VehiclePositions</td>\n",
+       "      <td>91d169b8e9fcb9a97df20555ffaeeac6</td>\n",
+       "      <td>111</td>\n",
+       "      <td>1</td>\n",
+       "      <td>[100, 120]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30225</th>\n",
+       "      <td>Long Beach VehiclePositions</td>\n",
+       "      <td>f68f97053f8855815c41fd039190a215</td>\n",
+       "      <td>112</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[100, 120]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31005</th>\n",
+       "      <td>Long Beach VehiclePositions</td>\n",
+       "      <td>e126fe422b0d1993702ac7eeeb98b902</td>\n",
+       "      <td>61</td>\n",
+       "      <td>1</td>\n",
+       "      <td>[100, 120]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31026</th>\n",
+       "      <td>Long Beach VehiclePositions</td>\n",
+       "      <td>0d5000c9ca7d1f79d15de52f20e1e80b</td>\n",
+       "      <td>71</td>\n",
+       "      <td>1</td>\n",
+       "      <td>[20, 40]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31081</th>\n",
+       "      <td>Long Beach VehiclePositions</td>\n",
+       "      <td>7e666104663ec1f274522fcdb92da971</td>\n",
+       "      <td>94</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[20, 40]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31087</th>\n",
+       "      <td>Long Beach VehiclePositions</td>\n",
+       "      <td>febe878e7c4b58adac06cf5d76b22806</td>\n",
+       "      <td>94</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[20, 40]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31099</th>\n",
+       "      <td>Long Beach VehiclePositions</td>\n",
+       "      <td>92e687535ed8c8894a36678dacad1ae8</td>\n",
+       "      <td>94</td>\n",
+       "      <td>1</td>\n",
+       "      <td>[20, 40]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>134 rows × 5 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 gtfs_dataset_name                 trip_instance_key route_id  \\\n",
+       "30184  Long Beach VehiclePositions  25e1d510b95ab5fddd45546b91701f44      111   \n",
+       "30192  Long Beach VehiclePositions  c3b492eb6f7a0548a5579b04405f7a39      111   \n",
+       "30198  Long Beach VehiclePositions  1061aea0c07107fc014beb06f10aae31      111   \n",
+       "30205  Long Beach VehiclePositions  91d169b8e9fcb9a97df20555ffaeeac6      111   \n",
+       "30225  Long Beach VehiclePositions  f68f97053f8855815c41fd039190a215      112   \n",
+       "...                            ...                               ...      ...   \n",
+       "31005  Long Beach VehiclePositions  e126fe422b0d1993702ac7eeeb98b902       61   \n",
+       "31026  Long Beach VehiclePositions  0d5000c9ca7d1f79d15de52f20e1e80b       71   \n",
+       "31081  Long Beach VehiclePositions  7e666104663ec1f274522fcdb92da971       94   \n",
+       "31087  Long Beach VehiclePositions  febe878e7c4b58adac06cf5d76b22806       94   \n",
+       "31099  Long Beach VehiclePositions  92e687535ed8c8894a36678dacad1ae8       94   \n",
+       "\n",
+       "       direction_id occupancy_percentage_array  \n",
+       "30184             0                 [100, 120]  \n",
+       "30192             0                 [100, 120]  \n",
+       "30198             1                 [100, 120]  \n",
+       "30205             1                 [100, 120]  \n",
+       "30225             0                 [100, 120]  \n",
+       "...             ...                        ...  \n",
+       "31005             1                 [100, 120]  \n",
+       "31026             1                   [20, 40]  \n",
+       "31081             0                   [20, 40]  \n",
+       "31087             0                   [20, 40]  \n",
+       "31099             1                   [20, 40]  \n",
+       "\n",
+       "[134 rows x 5 columns]"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# At best, for Long Beach and Fresno, can flag which seem to be busy route-directions\n",
+    "occupancy_by_trip[\n",
+    "    (occupancy_by_trip.gtfs_dataset_name.isin([\"Fresno Vehicle Positions\", \"Long Beach VehiclePositions\"])) &\n",
+    "    (occupancy_by_trip.distinct_array_values > 1) &\n",
+    "    (occupancy_by_trip.is_zero==False)\n",
+    "][[\"gtfs_dataset_name\", \"trip_instance_key\", \n",
+    "   \"route_id\", \"direction_id\", \"occupancy_percentage_array\"\n",
+    "  ]].sort_values([\"route_id\", \"direction_id\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9bcacad-dfe0-4ddd-8d7a-ca5ef3bf34b4",
+   "metadata": {},
+   "source": [
+    "### header_message / vehicle_message age\t\n",
+    "* Take a look at how Farhad has set this up for data quality checks\n",
+    "* These columns need to be carried from `fct_vehicle_locations` and arrays brought in for trip-level metrics.\n",
+    "* Right now, daily percentiles (25, 50 75, 90, 95, 99th percentiles) are calculated. But we cannot calculate percentiles without full arrays."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "3feb590f-0441-42c8-8963-2b20a625eb1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cols_to_look_at = [\"avg_header_message_age\", \"avg_vehicle_message_age\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "8b7407fe-18ea-4542-aa55-a24f920714e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>gtfs_dataset_name</th>\n",
+       "      <th>service_date</th>\n",
+       "      <th>route_id</th>\n",
+       "      <th>direction_id</th>\n",
+       "      <th>trip_instance_key</th>\n",
+       "      <th>stop_id</th>\n",
+       "      <th>current_stop_sequence</th>\n",
+       "      <th>avg_header_message_age</th>\n",
+       "      <th>avg_vehicle_message_age</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Bay Area 511 Tri-Valley Wheels VehiclePositions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>30R</td>\n",
+       "      <td>0</td>\n",
+       "      <td>f8fa2a2674386c58bdcfff5f5ec51874</td>\n",
+       "      <td>None</td>\n",
+       "      <td>21</td>\n",
+       "      <td>-2.750000</td>\n",
+       "      <td>7.250000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>131</th>\n",
+       "      <td>Bay Area 511 Tri-Valley Wheels VehiclePositions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>30R</td>\n",
+       "      <td>0</td>\n",
+       "      <td>f8fa2a2674386c58bdcfff5f5ec51874</td>\n",
+       "      <td>None</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-2.090909</td>\n",
+       "      <td>7.454545</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>220255</th>\n",
+       "      <td>Bay Area 511 Tri-Valley Wheels VehiclePositions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>30R</td>\n",
+       "      <td>0</td>\n",
+       "      <td>f8fa2a2674386c58bdcfff5f5ec51874</td>\n",
+       "      <td>None</td>\n",
+       "      <td>12</td>\n",
+       "      <td>-2.000000</td>\n",
+       "      <td>3.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>384820</th>\n",
+       "      <td>Bay Area 511 Tri-Valley Wheels VehiclePositions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>30R</td>\n",
+       "      <td>0</td>\n",
+       "      <td>f8fa2a2674386c58bdcfff5f5ec51874</td>\n",
+       "      <td>None</td>\n",
+       "      <td>13</td>\n",
+       "      <td>-2.200000</td>\n",
+       "      <td>9.800000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>384840</th>\n",
+       "      <td>Bay Area 511 Tri-Valley Wheels VehiclePositions</td>\n",
+       "      <td>2026-01-01</td>\n",
+       "      <td>30R</td>\n",
+       "      <td>0</td>\n",
+       "      <td>f8fa2a2674386c58bdcfff5f5ec51874</td>\n",
+       "      <td>None</td>\n",
+       "      <td>23</td>\n",
+       "      <td>-1.750000</td>\n",
+       "      <td>6.500000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                      gtfs_dataset_name service_date route_id  \\\n",
+       "0       Bay Area 511 Tri-Valley Wheels VehiclePositions   2026-01-01      30R   \n",
+       "131     Bay Area 511 Tri-Valley Wheels VehiclePositions   2026-01-01      30R   \n",
+       "220255  Bay Area 511 Tri-Valley Wheels VehiclePositions   2026-01-01      30R   \n",
+       "384820  Bay Area 511 Tri-Valley Wheels VehiclePositions   2026-01-01      30R   \n",
+       "384840  Bay Area 511 Tri-Valley Wheels VehiclePositions   2026-01-01      30R   \n",
+       "\n",
+       "        direction_id                 trip_instance_key stop_id  \\\n",
+       "0                  0  f8fa2a2674386c58bdcfff5f5ec51874    None   \n",
+       "131                0  f8fa2a2674386c58bdcfff5f5ec51874    None   \n",
+       "220255             0  f8fa2a2674386c58bdcfff5f5ec51874    None   \n",
+       "384820             0  f8fa2a2674386c58bdcfff5f5ec51874    None   \n",
+       "384840             0  f8fa2a2674386c58bdcfff5f5ec51874    None   \n",
+       "\n",
+       "        current_stop_sequence  avg_header_message_age  avg_vehicle_message_age  \n",
+       "0                          21               -2.750000                 7.250000  \n",
+       "131                         1               -2.090909                 7.454545  \n",
+       "220255                     12               -2.000000                 3.000000  \n",
+       "384820                     13               -2.200000                 9.800000  \n",
+       "384840                     23               -1.750000                 6.500000  "
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[df.trip_instance_key==\"f8fa2a2674386c58bdcfff5f5ec51874\"][trip_cols + stop_cols + cols_to_look_at].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9852916-b3da-4f36-9ad3-1e619334a9c2",
+   "metadata": {},
+   "source": [
+    "###  speed, odometer, bearing\n",
+    "Values: `speed: min, max, avg`\n",
+    "\n",
+    "* How many are null vs populated? Is this operator-specific or are nulls randomly distributed throughout?\n",
+    "* Within those that are populated, what does distribution look like? Is it usable or is it capturing acceleration with blips? Can we average it and smooth it out?\n",
+    "\n",
+    "\n",
+    "Values: `odometer: min, max`\n",
+    "\n",
+    "* How many are null vs populated? Is this operator-specific or are nulls randomly distributed throughout?\n",
+    "* Does this monotonically increase through trip progression? Is it accurately capturing the distance traveled between stops?\n",
+    "* Sanity check: how would a derived scheduled stop times + stop position -> stop's distance along shape -> difference between that would be odometer reading\n",
+    "\n",
+    "Values: `position_bearing_array`\n",
+    "\n",
+    "* How many are null vs populated? Is this operator-specific or are nulls randomly distributed throughout?\n",
+    "* What do values here look like?\n",
+    "* How would position bearing be translated to direction to be used in a meaningful way?\n",
+    "\n",
+    "**Findings**\n",
+    "* Just bring in arrays for now, for trip, ordered by vehicle position for all these columns.\n",
+    "* Odometer seems to be null throughout, min/max didn't capture anything. Not useful for us, and without that, potentially could see if `speed` column could back out `odometer` based on timestamp deltas.\n",
+    "* Bearing potentially could be useful. `speed`, `bearing` would potentially be useful, though less so if we have `movingpandas` columns.\n",
+    "* There are nulls, so ARRAY_AGG should ignore those. Also get counts for non-null values for all these columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "dd208443-16f6-415b-bdcc-fa573d32990d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trip_cols = [\n",
+    "    \"gtfs_dataset_name\", \"service_date\", \n",
+    "    \"route_id\", \"direction_id\", \n",
+    "    \"trip_instance_key\", \n",
+    "]\n",
+    "\n",
+    "stop_cols = [\"stop_id\", \"current_stop_sequence\"]\n",
+    "cols_to_look_at = [\"min_speed\", \"avg_speed\", \"max_speed\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "fb6ce978-d0d7-4ac4-9f4d-04101f458bff",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "max_speed\n",
+       "0.000000     7.561055e-02\n",
+       "9.834880     1.421567e-02\n",
+       "8.940800     1.356613e-02\n",
+       "0.044704     1.265714e-02\n",
+       "8.046720     1.210774e-02\n",
+       "                 ...     \n",
+       "20.501978    4.551782e-07\n",
+       "1.105532     4.551782e-07\n",
+       "21.298330    4.551782e-07\n",
+       "1.091127     4.551782e-07\n",
+       "1.144629     4.551782e-07\n",
+       "Name: proportion, Length: 44014, dtype: float64"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.max_speed.value_counts(dropna=False, normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "61df4172-d463-4d67-bb41-84d1058fe2f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "min_speed\n",
+       "0.000000     2.333589e-01\n",
+       "0.044704     3.349155e-02\n",
+       "9.834880     9.850055e-03\n",
+       "8.940800     9.436298e-03\n",
+       "6.705600     8.842291e-03\n",
+       "                 ...     \n",
+       "1.340000     4.551782e-07\n",
+       "13.120000    4.551782e-07\n",
+       "13.179552    4.551782e-07\n",
+       "6.870000     4.551782e-07\n",
+       "22.995468    4.551782e-07\n",
+       "Name: proportion, Length: 40251, dtype: float64"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.min_speed.value_counts(dropna=False, normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "2e4cbe47-a0eb-4563-bc12-d9ed4f758f9e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "avg_speed\n",
+       "0.000000    7.561055e-02\n",
+       "9.834880    8.819077e-03\n",
+       "0.044704    8.433541e-03\n",
+       "8.940800    8.255111e-03\n",
+       "NaN         7.674759e-03\n",
+       "                ...     \n",
+       "7.775246    4.551782e-07\n",
+       "8.444190    4.551782e-07\n",
+       "9.455568    4.551782e-07\n",
+       "0.837337    4.551782e-07\n",
+       "9.434830    4.551782e-07\n",
+       "Name: proportion, Length: 329476, dtype: float64"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.avg_speed.value_counts(dropna=False, normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "d16048a3-911d-460f-b5fd-9b726e0ac0a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trip_cols = [\n",
+    "    \"gtfs_dataset_name\", \"service_date\", \n",
+    "    \"route_id\", \"direction_id\", \n",
+    "    \"trip_instance_key\", \n",
+    "]\n",
+    "\n",
+    "stop_cols = [\"stop_id\", \"current_stop_sequence\"]\n",
+    "cols_to_look_at = [\"min_odometer\", \"max_odometer\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "eac8ef03-c099-4fcb-9ee3-2d18a2fc0bbe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "min_odometer\n",
+       "NaN    1.0\n",
+       "Name: proportion, dtype: float64"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[trip_cols + stop_cols + cols_to_look_at].min_odometer.value_counts(dropna=False, normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "dea6f13e-d895-480e-97cb-b8d5630c1123",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "max_odometer\n",
+       "NaN    1.0\n",
+       "Name: proportion, dtype: float64"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[trip_cols + stop_cols + cols_to_look_at].max_odometer.value_counts(dropna=False, normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "f15c4ff1-bddf-4826-bca6-174d593413e0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "distinct_array_values\n",
+       "1      4.236583e-01\n",
+       "2      2.958805e-01\n",
+       "3      1.204632e-01\n",
+       "0      6.455286e-02\n",
+       "4      4.459235e-02\n",
+       "           ...     \n",
+       "169    7.037268e-07\n",
+       "198    7.037268e-07\n",
+       "133    7.037268e-07\n",
+       "134    7.037268e-07\n",
+       "146    7.037268e-07\n",
+       "Name: proportion, Length: 168, dtype: float64"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bearing_by_trip = aggregate_array_by_group(df, trip_cols + stop_cols, \"position_bearing_array\")\n",
+    "bearing_by_trip.distinct_array_values.value_counts(normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "6de89ba2-1dbb-4481-b73e-574499e7eff7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1287101                                       [358.4, 358.6]\n",
+       "888559     [0.0, 0.8, 3.0, 104.0, 178.6, 180.3, 182.0, 18...\n",
+       "103194                          [294.0, 297.0, 301.0, 306.0]\n",
+       "951263                                               [298.0]\n",
+       "429557                                               [255.0]\n",
+       "27810                    [210.0, 211.0, 212.0, 246.0, 249.0]\n",
+       "197000                                               [225.0]\n",
+       "94318                                  [138.0, 146.0, 147.0]\n",
+       "1378734                             [229.51, 229.73, 230.66]\n",
+       "72448                                         [141.0, 157.0]\n",
+       "Name: position_bearing_array, dtype: object"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bearing_by_trip.position_bearing_array.sample(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdeb7593-b055-4b34-82cb-cc0c43c5e709",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Pyproject Local (use-venv)",
+   "language": "python",
+   "name": "pyproject_local_kernel_use_venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rt_vehicle_positions/download_vp_additional_metrics.py
+++ b/rt_vehicle_positions/download_vp_additional_metrics.py
@@ -1,0 +1,26 @@
+"""
+Download vp tables aggregated to stop / trip for 1 service_date.
+"""
+
+import gcsfs
+from gtfs_curator_utils import bq_utils
+
+VP_GCS = "gs://calitp-analytics-data/data-analyses/rt_vehicle_positions/"
+
+if __name__ == "__main__":
+
+    analysis_date = "2026-01-01"
+
+    for t in ["stop", "trip"]:
+        df = bq_utils.download_table(
+            project_name="cal-itp-data-infra-staging",
+            dataset_name="tiffany_mart_gtfs",
+            table_name=f"vp_additional_{t}_info",
+            date_col="service_date",
+            start_date=analysis_date,
+            end_date=analysis_date,
+        )
+
+        df.to_parquet(f"{VP_GCS}vp_{t}_metrics.parquet", filesystem=gcsfs.GCSFileSystem())
+
+        del df

--- a/rt_vehicle_positions/fct_vehicle_locations_additional_metrics.sql
+++ b/rt_vehicle_positions/fct_vehicle_locations_additional_metrics.sql
@@ -1,0 +1,95 @@
+-- use fct_vehicle_locations and aggregate to trip or trip-stop
+
+----------------------------------------------------------
+-- (1) metrics that pertain to stop
+----------------------------------------------------------
+WITH vehicle_locations AS (
+    SELECT
+		service_date,
+		base64_url,
+		gtfs_dataset_name,
+		schedule_feed_key,
+		schedule_base64_url,
+		schedule_name,
+		trip_instance_key,
+		stop_id,
+		current_stop_sequence,
+		current_status,
+
+		key,
+		_header_message_age,
+		_vehicle_message_age,
+		position_bearing,
+		position_odometer,
+		position_speed,
+
+		congestion_level,
+		occupancy_status,
+		occupancy_percentage,
+
+    FROM `cal-itp-data-infra-staging.tiffany_mart_gtfs.fct_vehicle_locations`
+    WHERE dt IN ('2026-01-01', '2026-01-02')
+),
+
+stop_metrics AS (
+	SELECT
+	    service_date,
+	    base64_url,
+		gtfs_dataset_name,
+		schedule_feed_key,
+		schedule_base64_url,
+		schedule_name,
+	    trip_instance_key,
+	    stop_id,
+		current_stop_sequence,
+		current_status,
+
+		AVG(_header_message_age) AS avg_header_message_age, -- farhad does more percentiles, but get this column
+		AVG(_vehicle_message_age) AS avg_vehicle_message_age,
+
+		MIN(position_speed) AS min_speed,
+		MAX(position_speed) AS max_speed,
+		AVG(position_speed) AS avg_speed,
+		MAX(position_odometer) AS max_odometer,
+		MIN(position_odometer) AS min_odometer,
+		ARRAY_AGG(DISTINCT position_bearing IGNORE NULLS) AS position_bearing_array,
+		ARRAY_AGG(DISTINCT congestion_level IGNORE NULLS),
+		COUNT(congestion_level) AS count_congestion_level,
+		COUNT(occupancy_status) AS count_occupancy_status,
+		ARRAY_AGG(occupancy_percentage IGNORE NULLS) AS occupancy_percentage_array,
+		COUNT(key) AS n_vp,
+
+	FROM vehicle_locations
+	GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+)
+
+SELECT * FROM stop_metrics
+
+
+----------------------------------------------------------
+-- (2) metrics that pertain to fct_vp_trip_summaries
+-- other columns we haven't used yet
+----------------------------------------------------------
+WITH trip_metrics AS (
+    SELECT
+        service_date,
+        base64_url,
+        schedule_base64_url,
+		trip_id,
+		iteration_num,
+        trip_instance_key,
+
+		trip_route_ids,
+		trip_direction_ids,
+		trip_schedule_relationships,
+
+		-- does this show 1?
+		num_distinct_header_timestamps,
+    	-- these 2 are used in fct_daily_schedule_rt_route_direction_summary for messages per minute
+		num_distinct_extract_ts,
+    	extract_duration_minutes,
+    FROM `cal-itp-data-infra-staging.tiffany_mart_gtfs.fct_vehicle_positions_trip_summaries`
+    WHERE service_date = '2026-01-01'
+)
+
+SELECT * FROM trip_metrics


### PR DESCRIPTION
Download 1 `service_date` and look at how complete the experiemental columns are from `fct_vehicle_locations`.

For `speed`, `odometer, `bearing`, those are vp grain, and we'll save those out as arrays into `fct_vp_trip_metrics`. 
* `speed` is a maybe
* `odometer` is mostly null
* `bearing` is populated
* probably what we can get from `movingpandas` will be better, but at least having these as arrays will allow for the comparison.

For `stop`, `current_status=STOPPED_AT` isn't useful at all. We will have to use `StopTimeUpdates` for actual arrival.
* `current_status` is populated, probably one of the most complete here.
* we do not have enough stops show up with `STOPPED_AT` per trip to back out a vp-derived-actual-arrival. Fresno and Long Beach have more info, but then their `stop_id/current_stop_sequence` columns are null....simply a groupby over a null group with more values.

The least useful columns are `congestion_level` (mostly unknown is set), `occupancy_status`, `occupancy_percentage`. Track these columns at trip grain to see whether these improve. 
* `count(congestion_level)` would show us lots of non-null values, but those values are `UNKNOWN_CONGESTION_LEVEL`, not actually useful
* `count(occupancy_percentage)` would show us lots of null values, so we'd know that column isn't useful