### PR TITLE
NTD conceptual map + consolidate annual `fct` metric tables

### DIFF
--- a/ntd/annual.sql
+++ b/ntd/annual.sql
@@ -1,9 +1,10 @@
 ----------------------------------------------------------
 -- (1) tiffany_mart_ntd_explore.fct_service_data_time_series_by_mode
--- fct_service_data_and_operating_expenses_time_series_by_mode_upt/voms/vrh feel repetitive
+-- fct_service_data_and_operating_expenses_time_series_by_mode_[one_excel_sheet] feel repetitive
+-- service values: upt, vrh, vrm, voms, pmt
+-- funding values: vo, vm, nvm, ga, total
 -- what's there: noticed that intermediate tables all use `dim_agency_information`
 -- what I want to change: combine the intermediate tables, then bring in dim_agency_information, and filter out bad keys
-
 ----------------------------------------------------------
 WITH int_upt AS (
     SELECT *
@@ -35,46 +36,115 @@ int_pmt AS (
     --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_pmt') }}
 ),
 
+-- funding
+int_vo AS (
+    SELECT *
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_vo`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_vo') }}
+),
+
+int_vm AS (
+    SELECT *
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_vm`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_vm') }}
+),
+
+int_ga AS (
+    SELECT *
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_ga`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_ga') }}
+),
+
+int_nvm AS (
+    SELECT *
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_nvm`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_nvm') }}
+),
+
+int_total AS (
+    SELECT *
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_total`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_total') }}
+),
+
+-- do this here, because int_ tables fix some values, such as NTD_ID
+-- grab upt and opexp_total as representatives
+agency_identifiers AS (
+    SELECT
+        key,
+        ntd_id,
+        mode,
+        year,
+        type_of_service,
+
+        agency_status,
+        census_year,
+        last_report_year,
+        mode_status,
+        reporter_type,
+        reporting_module,
+        uace_code,
+        uza_area_sq_miles,
+        primary_uza_name,
+        uza_population,
+        agency_name AS source_agency,
+        city AS source_city,
+        state AS source_state,
+        dt,
+        execution_ts,
+    FROM int_upt
+    UNION ALL
+    SELECT * int_total
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+),
+
 t1 AS (
     SELECT
-        COALESCE(int_upt.key, int_vrh.key, int_vrm.key, int_voms.key, int_pmt.key) AS key,
-        COALESCE(int_upt.ntd_id, int_vrh.ntd_id, int_vrm.ntd_id, int_voms.ntd_id, int_pmt.ntd_id) AS ntd_id,
-        COALESCE(int_upt.year, int_vrh.year, int_vrm.year, int_voms.year, int_pmt.year) AS year,
+        COALESCE(int_upt.key, int_vrh.key, int_vrm.key, int_voms.key, int_pmt.key, int_vp.key, int_vm.key, int_nvm.key, int_ga.key, int_total.key) AS key,
+        agency_identifiers.ntd_id,
+        agency_identifiers.mode,
+        agency_identifiers.year,
+        agency_identifiers.type_of_service,
 
-        COALESCE(int_upt.mode, int_vrh.mode, int_vrm.mode, int_voms.mode, int_pmt.mode) AS mode,
-        COALESCE(int_upt.type_of_service, int_vrh.type_of_service, int_vrm.type_of_service, int_voms.type_of_service, int_pmt.type_of_service) AS type_of_service,
-        COALESCE(int_upt.agency_status, int_vrh.agency_status, int_vrm.agency_status, int_voms.agency_status, int_pmt.agency_status) AS agency_status,
-        COALESCE(int_upt.census_year, int_vrh.census_year, int_vrm.census_year, int_voms.census_year, int_pmt.census_year) AS census_year,
-        COALESCE(int_upt.last_report_year, int_vrh.last_report_year, int_vrm.last_report_year, int_voms.last_report_year, int_pmt.last_report_year) AS last_report_year,
-        COALESCE(int_upt.mode_status, int_vrh.mode_status, int_vrm.mode_status, int_voms.mode_status, int_pmt.mode_status) AS mode_status,
-        COALESCE(int_upt.reporter_type, int_vrh.reporter_type, int_vrm.reporter_type, int_voms.reporter_type, int_pmt.reporter_type) AS reporter_type,
-        COALESCE(int_upt.reporting_module, int_vrh.reporting_module, int_vrm.reporting_module, int_voms.reporting_module, int_pmt.reporting_module) AS reporting_module,
-        COALESCE(int_upt.uace_code, int_vrh.uace_code, int_vrm.uace_code, int_voms.uace_code, int_pmt.uace_code) AS uace_code,
-        COALESCE(int_upt.uza_area_sq_miles, int_vrh.uza_area_sq_miles, int_vrm.uza_area_sq_miles, int_voms.uza_area_sq_miles, int_pmt.uza_area_sq_miles) AS uza_area_sq_miles,
-        COALESCE(int_upt.primary_uza_name, int_vrh.primary_uza_name, int_vrm.primary_uza_name, int_voms.primary_uza_name, int_pmt.primary_uza_name) AS primary_uza_name,
-        COALESCE(int_upt.uza_population, int_vrh.uza_population, int_vrm.uza_population, int_voms.uza_population, int_pmt.uza_population) AS uza_population,
+        int_upt.upt AS unlinked_passenger_trips,
+        int_vrh.vrh AS vehicle_revenue_hours,
+        int_vrm.vrm AS vehicle_revenue_miles,
+        int_voms.voms AS vehicles_operated_in_maxiumum_service,
+        int_pmt.pmt AS passenger_miles_traveled,
 
-        int_upt.upt,
-        int_vrh.vrh,
-        int_vrm.vrm,
-        int_voms.voms,
-        int_pmt.pmt,
+        int_vo.opexp_vo AS operating_expenses_vehicle_operations,
+        int_vm.opexp_vm AS operating_expenses_vehicle_maintenance,
+        int_nvm.opexp_nvm AS operating_expenses_nonvehicle_maintenance,
+        int_ga.opexp_ga AS operating_expenses_general_administration,
+        int_total.opexp_total AS operating_expenses_total,
 
-        COALESCE(int_upt.agency_name, int_vrh.agency_name, int_vrm.agency_name, int_voms.agency_name, int_pmt.agency_name) AS source_agency,
-        COALESCE(int_upt.city, int_vrh.city, int_vrm.city, int_voms.city, int_pmt.city) AS source_city,
-        COALESCE(int_upt.state, int_vrh.state, int_vrm.state, int_voms.state, int_pmt.state) AS source_state,
-        COALESCE(int_upt.dt, int_vrh.dt, int_vrm.dt, int_voms.dt, int_pmt.dt) AS dt, -- are these the same across all the datasets?
-        COALESCE(int_upt.execution_ts, int_vrh.execution_ts, int_vrm.execution_ts, int_voms.execution_ts, int_pmt.execution_ts) AS execution_Ts, -- are these the same across all the datasets?
+        agency_identifiers.agency_status,
+        agency_identifiers.census_year,
+        agency_identifiers.last_report_year,
+        agency_identifiers.mode_status,
+        agency_identifiers.reporter_type,
+        agency_identifiers.reporting_module,
+        agency_identifiers.uace_code,
+        agency_identifiers.uza_area_sq_miles,
+        agency_identifiers.primary_uza_name,
+        agency_identifiers.uza_population,
+        agency_identifiers.source_agency,
+        agency_identifiers.source_city,
+        agency_identifiers.source_state,
+        agency_identifiers.dt,
+        agency_identifiers.execution_ts,
 
     FROM int_upt
-    LEFT JOIN int_vrh
-        USING (key)
-    LEFT JOIN int_vrm
-        USING (key)
-    LEFT JOIN int_voms
-        USING (key)
-    LEFT JOIN int_pmt
-        USING (key)
+    LEFT JOIN int_vrh USING (key)
+    LEFT JOIN int_vrm USING (key)
+    LEFT JOIN int_voms USING (key)
+    LEFT JOIN int_pmt USING (key)
+    LEFT JOIN int_vp USING (key)
+    LEFT JOIN int_vm USING (key)
+    LEFT JOIN int_nvm USING (key)
+    LEFT JOIN int_ga USING (key)
+    LEFT JOIN int_total USING (key)
+    LEFT JOIN agency_identifiers USING (key)
 )
 
 SELECT * FROM t1

--- a/ntd/annual.sql
+++ b/ntd/annual.sql
@@ -1,7 +1,7 @@
 ----------------------------------------------------------
 -- (1) tiffany_mart_ntd_explore.fct_service_data_time_series_by_mode
 -- fct_service_data_and_operating_expenses_time_series_by_mode_[one_excel_sheet] feel repetitive
--- service values: upt, vrh, vrm, voms, pmt
+-- service values: upt, vrh, vrm, voms, pmt, drm (directional_route_miles)
 -- funding values: vo, vm, nvm, ga, total
 -- what's there: noticed that intermediate tables all use `dim_agency_information`
 -- what I want to change: combine the intermediate tables, then bring in dim_agency_information, and filter out bad keys
@@ -36,6 +36,12 @@ int_pmt AS (
     --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_pmt') }}
 ),
 
+int_drm AS (
+    SELECT *
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_drm`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_drm') }}
+),
+
 -- funding
 int_vo AS (
     SELECT *
@@ -67,16 +73,66 @@ int_total AS (
     --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_total') }}
 ),
 
+t1 AS (
+    SELECT
+        COALESCE(int_upt.key, int_vrh.key, int_vrm.key, int_voms.key, int_pmt.key, int_vo.key, int_vm.key, int_nvm.key, int_ga.key, int_total.key) AS key,
+        COALESCE(int_upt.ntd_id, int_vrh.ntd_id, int_vrm.ntd_id, int_voms.ntd_id, int_pmt.ntd_id, int_vo.ntd_id, int_vm.ntd_id, int_nvm.ntd_id, int_ga.ntd_id, int_total.ntd_id) AS ntd_id,
+        COALESCE(int_upt.mode, int_vrh.mode, int_vrm.mode, int_voms.mode, int_pmt.mode, int_vo.mode, int_vm.mode, int_nvm.mode, int_ga.mode, int_total.mode) AS mode,
+        COALESCE(int_upt.year, int_vrh.year, int_vrm.year, int_voms.year, int_pmt.year, int_vo.year, int_vm.year, int_nvm.year, int_ga.year, int_total.year) AS year,
+        COALESCE(int_upt.type_of_service, int_vrh.type_of_service, int_vrm.type_of_service, int_voms.type_of_service, int_pmt.type_of_service, int_vo.type_of_service, int_vm.type_of_service, int_nvm.type_of_service, int_ga.type_of_service, int_total.type_of_service) AS type_of_service,
+
+        int_upt.upt AS unlinked_passenger_trips,
+        int_vrh.vrh AS vehicle_revenue_hours,
+        int_vrm.vrm AS vehicle_revenue_miles,
+        int_voms.voms AS vehicles_operated_in_maxiumum_service,
+        int_pmt.pmt AS passenger_miles_traveled,
+        int_drm.drm AS direction_route_miles,
+
+        int_vo.opexp_vo AS operating_expenses_vehicle_operations,
+        int_vm.opexp_vm AS operating_expenses_vehicle_maintenance,
+        int_nvm.opexp_nvm AS operating_expenses_nonvehicle_maintenance,
+        int_ga.opexp_ga AS operating_expenses_general_administration,
+        int_total.opexp_total AS operating_expenses_total,
+
+    FROM int_upt
+    LEFT JOIN int_vrh USING (key)
+    LEFT JOIN int_vrm USING (key)
+    LEFT JOIN int_voms USING (key)
+    LEFT JOIN int_pmt USING (key)
+    LEFT JOIN int_drm USING (key)
+    LEFT JOIN int_vo USING (key)
+    LEFT JOIN int_vm USING (key)
+    LEFT JOIN int_nvm USING (key)
+    LEFT JOIN int_ga USING (key)
+    LEFT JOIN int_total USING (key)
+)
+
+SELECT * FROM t1
+
+
+
+
+WHERE key NOT IN ('e41f3812655066d28ec4bbc851545517','f5f160d19e3753e3a99d9ad55b4f2210','7d3e30725b3fa42c6d1722308f9cc855',
+    'da108425cb2696446aa1017bca72340f','a31019318eddb35b747ab79470e10017','98692053a5a16aae8ef8e2579f19b8a3',
+    'd6809f84a9d19808f8b1f013fc1cd537','c3ae0b0299c10ffa25e1193404762136','564993fcc3a920cc0800005f3af9fd73',
+    '73f01d2aa1c268ec1dafbcf1fdaa84fc','5b13563073a95faa05c9da4f77c0b3a8','0fab2ef186a2a74edc98d16427d4d61a'
+)
+
+-- step 1 sanity check:
+-- do all the left joins work? do any rows drop? if nothing, can it be inner join? (did both left and inner join, and both got 47_820 rows)
+-- the keys are dbt_utils.generate_surrogate_key(['ntd_id', 'year', 'mode', 'type_of_service']) }}
+
+----------------------------------------------------------
+-- (2) how do agency identifiers differ from dim_agency_information? the intermediatabe table is used for fct
+-- agency identifiers that show up on each sheet of Excel
+-- dim_agency_information isn't exactly the same, the columns are different
+-- there's dt and execution_ts, which updates every time it hits the view?
+----------------------------------------------------------
 -- do this here, because int_ tables fix some values, such as NTD_ID
 -- grab upt and opexp_total as representatives
-agency_identifiers AS (
+upt_agency_identifiers AS (
     SELECT
         key,
-        ntd_id,
-        mode,
-        year,
-        type_of_service,
-
         agency_status,
         census_year,
         last_report_year,
@@ -90,33 +146,38 @@ agency_identifiers AS (
         agency_name AS source_agency,
         city AS source_city,
         state AS source_state,
-        dt,
-        execution_ts,
+        --dt,
+        --execution_ts,
     FROM int_upt
-    UNION ALL
-    SELECT * int_total
-    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
 ),
 
-t1 AS (
+opexp_agency_identifiers AS (
     SELECT
-        COALESCE(int_upt.key, int_vrh.key, int_vrm.key, int_voms.key, int_pmt.key, int_vp.key, int_vm.key, int_nvm.key, int_ga.key, int_total.key) AS key,
-        agency_identifiers.ntd_id,
-        agency_identifiers.mode,
-        agency_identifiers.year,
-        agency_identifiers.type_of_service,
+        key,
+        agency_status,
+        census_year,
+        last_report_year,
+        mode_status,
+        reporter_type,
+        reporting_module,
+        uace_code,
+        uza_area_sq_miles,
+        primary_uza_name,
+        uza_population,
+        agency_name AS source_agency,
+        city AS source_city,
+        state AS source_state,
+        --dt,
+        --execution_ts,
+    FROM int_total
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
+),
 
-        int_upt.upt AS unlinked_passenger_trips,
-        int_vrh.vrh AS vehicle_revenue_hours,
-        int_vrm.vrm AS vehicle_revenue_miles,
-        int_voms.voms AS vehicles_operated_in_maxiumum_service,
-        int_pmt.pmt AS passenger_miles_traveled,
-
-        int_vo.opexp_vo AS operating_expenses_vehicle_operations,
-        int_vm.opexp_vm AS operating_expenses_vehicle_maintenance,
-        int_nvm.opexp_nvm AS operating_expenses_nonvehicle_maintenance,
-        int_ga.opexp_ga AS operating_expenses_general_administration,
-        int_total.opexp_total AS operating_expenses_total,
+agency_identifiers AS (
+    SELECT * FROM upt_agency_identifiers
+    UNION ALL SELECT * FROM opexp_agency_identifiers
+),
 
         agency_identifiers.agency_status,
         agency_identifiers.census_year,
@@ -131,29 +192,5 @@ t1 AS (
         agency_identifiers.source_agency,
         agency_identifiers.source_city,
         agency_identifiers.source_state,
-        agency_identifiers.dt,
-        agency_identifiers.execution_ts,
-
-    FROM int_upt
-    LEFT JOIN int_vrh USING (key)
-    LEFT JOIN int_vrm USING (key)
-    LEFT JOIN int_voms USING (key)
-    LEFT JOIN int_pmt USING (key)
-    LEFT JOIN int_vp USING (key)
-    LEFT JOIN int_vm USING (key)
-    LEFT JOIN int_nvm USING (key)
-    LEFT JOIN int_ga USING (key)
-    LEFT JOIN int_total USING (key)
-    LEFT JOIN agency_identifiers USING (key)
-)
-
-SELECT * FROM t1
-WHERE key NOT IN ('e41f3812655066d28ec4bbc851545517','f5f160d19e3753e3a99d9ad55b4f2210','7d3e30725b3fa42c6d1722308f9cc855',
-    'da108425cb2696446aa1017bca72340f','a31019318eddb35b747ab79470e10017','98692053a5a16aae8ef8e2579f19b8a3',
-    'd6809f84a9d19808f8b1f013fc1cd537','c3ae0b0299c10ffa25e1193404762136','564993fcc3a920cc0800005f3af9fd73',
-    '73f01d2aa1c268ec1dafbcf1fdaa84fc','5b13563073a95faa05c9da4f77c0b3a8','0fab2ef186a2a74edc98d16427d4d61a'
-)
-
--- step 1 sanity check:
--- do all the left joins work? do any rows drop? if nothing, can it be inner join? (did both left and inner join, and both got 47_820 rows)
--- the keys are dbt_utils.generate_surrogate_key(['ntd_id', 'year', 'mode', 'type_of_service']) }}
+        --agency_identifiers.dt,
+        --agency_identifiers.execution_ts,

--- a/ntd/annual.sql
+++ b/ntd/annual.sql
@@ -1,8 +1,9 @@
 ----------------------------------------------------------
--- (1)
+-- (1) tiffany_mart_ntd_explore.fct_service_data_time_series_by_mode
 -- fct_service_data_and_operating_expenses_time_series_by_mode_upt/voms/vrh feel repetitive
 -- what's there: noticed that intermediate tables all use `dim_agency_information`
 -- what I want to change: combine the intermediate tables, then bring in dim_agency_information, and filter out bad keys
+
 ----------------------------------------------------------
 WITH int_upt AS (
     SELECT *
@@ -36,7 +37,7 @@ int_pmt AS (
 
 t1 AS (
     SELECT
-
+        COALESCE(int_upt.key, int_vrh.key, int_vrm.key, int_voms.key, int_pmt.key) AS key,
         COALESCE(int_upt.ntd_id, int_vrh.ntd_id, int_vrm.ntd_id, int_voms.ntd_id, int_pmt.ntd_id) AS ntd_id,
         COALESCE(int_upt.year, int_vrh.year, int_vrm.year, int_voms.year, int_pmt.year) AS year,
 
@@ -46,9 +47,12 @@ t1 AS (
         COALESCE(int_upt.census_year, int_vrh.census_year, int_vrm.census_year, int_voms.census_year, int_pmt.census_year) AS census_year,
         COALESCE(int_upt.last_report_year, int_vrh.last_report_year, int_vrm.last_report_year, int_voms.last_report_year, int_pmt.last_report_year) AS last_report_year,
         COALESCE(int_upt.mode_status, int_vrh.mode_status, int_vrm.mode_status, int_voms.mode_status, int_pmt.mode_status) AS mode_status,
-        COALESCE(int_upt.last_report_year, int_vrh.last_report_year, int_vrm.last_report_year, int_voms.last_report_year, int_pmt.last_report_year) AS last_report_year,
         COALESCE(int_upt.reporter_type, int_vrh.reporter_type, int_vrm.reporter_type, int_voms.reporter_type, int_pmt.reporter_type) AS reporter_type,
-
+        COALESCE(int_upt.reporting_module, int_vrh.reporting_module, int_vrm.reporting_module, int_voms.reporting_module, int_pmt.reporting_module) AS reporting_module,
+        COALESCE(int_upt.uace_code, int_vrh.uace_code, int_vrm.uace_code, int_voms.uace_code, int_pmt.uace_code) AS uace_code,
+        COALESCE(int_upt.uza_area_sq_miles, int_vrh.uza_area_sq_miles, int_vrm.uza_area_sq_miles, int_voms.uza_area_sq_miles, int_pmt.uza_area_sq_miles) AS uza_area_sq_miles,
+        COALESCE(int_upt.primary_uza_name, int_vrh.primary_uza_name, int_vrm.primary_uza_name, int_voms.primary_uza_name, int_pmt.primary_uza_name) AS primary_uza_name,
+        COALESCE(int_upt.uza_population, int_vrh.uza_population, int_vrm.uza_population, int_voms.uza_population, int_pmt.uza_population) AS uza_population,
 
         int_upt.upt,
         int_vrh.vrh,
@@ -56,8 +60,12 @@ t1 AS (
         int_voms.voms,
         int_pmt.pmt,
 
-        --int.dt, -- are these the same across all the datasets?
-        --int.execution_ts -- are these the same across all the datasets?
+        COALESCE(int_upt.agency_name, int_vrh.agency_name, int_vrm.agency_name, int_voms.agency_name, int_pmt.agency_name) AS source_agency,
+        COALESCE(int_upt.city, int_vrh.city, int_vrm.city, int_voms.city, int_pmt.city) AS source_city,
+        COALESCE(int_upt.state, int_vrh.state, int_vrm.state, int_voms.state, int_pmt.state) AS source_state,
+        COALESCE(int_upt.dt, int_vrh.dt, int_vrm.dt, int_voms.dt, int_pmt.dt) AS dt, -- are these the same across all the datasets?
+        COALESCE(int_upt.execution_ts, int_vrh.execution_ts, int_vrm.execution_ts, int_voms.execution_ts, int_pmt.execution_ts) AS execution_Ts, -- are these the same across all the datasets?
+
     FROM int_upt
     LEFT JOIN int_vrh
         USING (key)
@@ -67,17 +75,15 @@ t1 AS (
         USING (key)
     LEFT JOIN int_pmt
         USING (key)
-
 )
 
 SELECT * FROM t1
-
--- remove bad rows for 'Advance Transit, Inc. NH' and 'Southern Teton Area Rapid Transit'
---WHERE int.key NOT IN ('e41f3812655066d28ec4bbc851545517','f5f160d19e3753e3a99d9ad55b4f2210','7d3e30725b3fa42c6d1722308f9cc855',
-    --'da108425cb2696446aa1017bca72340f','a31019318eddb35b747ab79470e10017','98692053a5a16aae8ef8e2579f19b8a3',
-    --    'd6809f84a9d19808f8b1f013fc1cd537','c3ae0b0299c10ffa25e1193404762136','564993fcc3a920cc0800005f3af9fd73',
-    --    '73f01d2aa1c268ec1dafbcf1fdaa84fc','5b13563073a95faa05c9da4f77c0b3a8','0fab2ef186a2a74edc98d16427d4d61a')
+WHERE key NOT IN ('e41f3812655066d28ec4bbc851545517','f5f160d19e3753e3a99d9ad55b4f2210','7d3e30725b3fa42c6d1722308f9cc855',
+    'da108425cb2696446aa1017bca72340f','a31019318eddb35b747ab79470e10017','98692053a5a16aae8ef8e2579f19b8a3',
+    'd6809f84a9d19808f8b1f013fc1cd537','c3ae0b0299c10ffa25e1193404762136','564993fcc3a920cc0800005f3af9fd73',
+    '73f01d2aa1c268ec1dafbcf1fdaa84fc','5b13563073a95faa05c9da4f77c0b3a8','0fab2ef186a2a74edc98d16427d4d61a'
+)
 
 -- step 1 sanity check:
--- do all the left joins work? do any rows drop? if nothing, can it be inner join? (did inner join, and both got 47_820 rows)
+-- do all the left joins work? do any rows drop? if nothing, can it be inner join? (did both left and inner join, and both got 47_820 rows)
 -- the keys are dbt_utils.generate_surrogate_key(['ntd_id', 'year', 'mode', 'type_of_service']) }}

--- a/ntd/annual.sql
+++ b/ntd/annual.sql
@@ -4,42 +4,41 @@
 -- what's there: noticed that intermediate tables all use `dim_agency_information`
 -- what I want to change: combine the intermediate tables, then bring in dim_agency_information, and filter out bad keys
 ----------------------------------------------------------
-WITH int_mode_upt AS (
+WITH int_upt AS (
     SELECT *
-    FROM {{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_upt') }}
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_upt`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_upt') }}
 ),
 
-int_mode_vrh AS (
+int_vrh AS (
     SELECT *
-    FROM {{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_vrh') }}
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_vrh`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_vrh') }}
 ),
 
-int_mode_vrm AS (
+int_vrm AS (
     SELECT *
-    FROM {{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_vrm') }}
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_vrm`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_vrm') }}
 ),
 
-int_mode_voms AS (
+int_voms AS (
     SELECT *
-    FROM {{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_voms') }}
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_voms`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_voms') }}
 ),
 
-int_mode_pmt AS (
+int_pmt AS (
     SELECT *
-    FROM {{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_pmt') }}
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_pmt`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_pmt') }}
 ),
 
-fct_service_data_and_operating_expenses_time_series_by_mode AS (
+t1 AS (
     SELECT
 
         COALESCE(int_upt.ntd_id, int_vrh.ntd_id, int_vrm.ntd_id, int_voms.ntd_id, int_pmt.ntd_id) AS ntd_id,
         COALESCE(int_upt.year, int_vrh.year, int_vrm.year, int_voms.year, int_pmt.year) AS year,
-
-        --agency.agency_name,
-        --agency.city,
-        --agency.state,
-        --agency.caltrans_district_current,
-        --agency.caltrans_district_name_current,
 
         COALESCE(int_upt.mode, int_vrh.mode, int_vrm.mode, int_voms.mode, int_pmt.mode) AS mode,
         COALESCE(int_upt.type_of_service, int_vrh.type_of_service, int_vrm.type_of_service, int_voms.type_of_service, int_pmt.type_of_service) AS type_of_service,
@@ -50,42 +49,35 @@ fct_service_data_and_operating_expenses_time_series_by_mode AS (
         COALESCE(int_upt.last_report_year, int_vrh.last_report_year, int_vrm.last_report_year, int_voms.last_report_year, int_pmt.last_report_year) AS last_report_year,
         COALESCE(int_upt.reporter_type, int_vrh.reporter_type, int_vrm.reporter_type, int_voms.reporter_type, int_pmt.reporter_type) AS reporter_type,
 
-        --int.reporting_module,
-        --int.uace_code,
-        --int.uza_area_sq_miles,
-        --int.primary_uza_name,
-        --int.uza_population,
-        --int.agency_name AS source_agency,
-        --int.city AS source_city,
-        --int.state AS source_state,
 
-        int_mode_upt.upt,
-        int_mode_vrh.vrh,
-        int_mode_vrm.vrm,
-        int_mode_voms.voms,
+        int_upt.upt,
+        int_vrh.vrh,
+        int_vrm.vrm,
+        int_voms.voms,
+        int_pmt.pmt,
 
-        int.dt, -- are these the same across all the datasets?
-        int.execution_ts -- are these the same across all the datasets?
-    FROM int_mode_upt
-    LEFT JOIN int_mode_vrh
+        --int.dt, -- are these the same across all the datasets?
+        --int.execution_ts -- are these the same across all the datasets?
+    FROM int_upt
+    LEFT JOIN int_vrh
         USING (key)
-    LEFT JOIN int_mode_vrm
+    LEFT JOIN int_vrm
         USING (key)
-    LEFT JOIN int_mode_voms
+    LEFT JOIN int_voms
         USING (key)
-    LEFT JOIN int_mode_pmt
+    LEFT JOIN int_pmt
         USING (key)
 
-    --LEFT JOIN dim_agency_information AS agency
-        ON int.ntd_id = agency.ntd_id
-            AND int.year = agency.year
-    -- remove bad rows for 'Advance Transit, Inc. NH' and 'Southern Teton Area Rapid Transit'
-    WHERE int.key NOT IN ('e41f3812655066d28ec4bbc851545517','f5f160d19e3753e3a99d9ad55b4f2210','7d3e30725b3fa42c6d1722308f9cc855',
-        'da108425cb2696446aa1017bca72340f','a31019318eddb35b747ab79470e10017','98692053a5a16aae8ef8e2579f19b8a3',
-        'd6809f84a9d19808f8b1f013fc1cd537','c3ae0b0299c10ffa25e1193404762136','564993fcc3a920cc0800005f3af9fd73',
-        '73f01d2aa1c268ec1dafbcf1fdaa84fc','5b13563073a95faa05c9da4f77c0b3a8','0fab2ef186a2a74edc98d16427d4d61a')
 )
 
+SELECT * FROM t1
+
+-- remove bad rows for 'Advance Transit, Inc. NH' and 'Southern Teton Area Rapid Transit'
+--WHERE int.key NOT IN ('e41f3812655066d28ec4bbc851545517','f5f160d19e3753e3a99d9ad55b4f2210','7d3e30725b3fa42c6d1722308f9cc855',
+    --'da108425cb2696446aa1017bca72340f','a31019318eddb35b747ab79470e10017','98692053a5a16aae8ef8e2579f19b8a3',
+    --    'd6809f84a9d19808f8b1f013fc1cd537','c3ae0b0299c10ffa25e1193404762136','564993fcc3a920cc0800005f3af9fd73',
+    --    '73f01d2aa1c268ec1dafbcf1fdaa84fc','5b13563073a95faa05c9da4f77c0b3a8','0fab2ef186a2a74edc98d16427d4d61a')
+
 -- step 1 sanity check:
--- do all the left joins work? do any rows drop? if nothing, can it be inner join?
+-- do all the left joins work? do any rows drop? if nothing, can it be inner join? (did inner join, and both got 47_820 rows)
 -- the keys are dbt_utils.generate_surrogate_key(['ntd_id', 'year', 'mode', 'type_of_service']) }}

--- a/ntd/annual.sql
+++ b/ntd/annual.sql
@@ -1,5 +1,5 @@
 ----------------------------------------------------------
--- (1) tiffany_mart_ntd_explore.fct_service_data_time_series_by_mode
+-- (1) tiffany_mart_ntd_explore.fct_service_data_and_operating_expenses_time_series_by_mode (did not remove keys)
 -- fct_service_data_and_operating_expenses_time_series_by_mode_[one_excel_sheet] feel repetitive
 -- service values: upt, vrh, vrm, voms, pmt, drm (directional_route_miles)
 -- funding values: vo, vm, nvm, ga, total
@@ -73,7 +73,12 @@ int_total AS (
     --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_total') }}
 ),
 
-t1 AS (
+int_agency_information AS (
+    SELECT *
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_agency_identifiers`
+),
+
+service_data_and_operating_expenses_time_series_by_mode AS (
     SELECT
         COALESCE(int_upt.key, int_vrh.key, int_vrm.key, int_voms.key, int_pmt.key, int_vo.key, int_vm.key, int_nvm.key, int_ga.key, int_total.key) AS key,
         COALESCE(int_upt.ntd_id, int_vrh.ntd_id, int_vrm.ntd_id, int_voms.ntd_id, int_pmt.ntd_id, int_vo.ntd_id, int_vm.ntd_id, int_nvm.ntd_id, int_ga.ntd_id, int_total.ntd_id) AS ntd_id,
@@ -94,6 +99,20 @@ t1 AS (
         int_ga.opexp_ga AS operating_expenses_general_administration,
         int_total.opexp_total AS operating_expenses_total,
 
+        int_agency_information.agency_status,
+        int_agency_information.census_year,
+        int_agency_information.last_report_year,
+        int_agency_information.mode_status,
+        int_agency_information.reporter_type,
+        int_agency_information.reporting_module,
+        int_agency_information.uace_code,
+        int_agency_information.uza_area_sq_miles,
+        int_agency_information.primary_uza_name,
+        int_agency_information.uza_population,
+        int_agency_information.source_agency,
+        int_agency_information.source_city,
+        int_agency_information.source_state,
+
     FROM int_upt
     LEFT JOIN int_vrh USING (key)
     LEFT JOIN int_vrm USING (key)
@@ -105,31 +124,46 @@ t1 AS (
     LEFT JOIN int_nvm USING (key)
     LEFT JOIN int_ga USING (key)
     LEFT JOIN int_total USING (key)
+    LEFT JOIN int_agency_information USING (key)
 )
 
-SELECT * FROM t1
-
-
-
-
-WHERE key NOT IN ('e41f3812655066d28ec4bbc851545517','f5f160d19e3753e3a99d9ad55b4f2210','7d3e30725b3fa42c6d1722308f9cc855',
+fct_service_data_and_operating_expenses_time_series_by_mode AS (
+    SELECT *
+    FROM service_data_and_operating_expenses_time_series_by_mode
+    WHERE key NOT IN ('e41f3812655066d28ec4bbc851545517','f5f160d19e3753e3a99d9ad55b4f2210','7d3e30725b3fa42c6d1722308f9cc855',
     'da108425cb2696446aa1017bca72340f','a31019318eddb35b747ab79470e10017','98692053a5a16aae8ef8e2579f19b8a3',
     'd6809f84a9d19808f8b1f013fc1cd537','c3ae0b0299c10ffa25e1193404762136','564993fcc3a920cc0800005f3af9fd73',
     '73f01d2aa1c268ec1dafbcf1fdaa84fc','5b13563073a95faa05c9da4f77c0b3a8','0fab2ef186a2a74edc98d16427d4d61a'
+    )
 )
+
+SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode
 
 -- step 1 sanity check:
 -- do all the left joins work? do any rows drop? if nothing, can it be inner join? (did both left and inner join, and both got 47_820 rows)
 -- the keys are dbt_utils.generate_surrogate_key(['ntd_id', 'year', 'mode', 'type_of_service']) }}
 
 ----------------------------------------------------------
--- (2) how do agency identifiers differ from dim_agency_information? the intermediatabe table is used for fct
+-- (2) tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_agency_identifiers
+-- how do agency identifiers differ from dim_agency_information? the intermediatabe table is used for fct
 -- agency identifiers that show up on each sheet of Excel
 -- dim_agency_information isn't exactly the same, the columns are different
 -- there's dt and execution_ts, which updates every time it hits the view?
 ----------------------------------------------------------
 -- do this here, because int_ tables fix some values, such as NTD_ID
 -- grab upt and opexp_total as representatives
+WITH int_upt AS (
+    SELECT *
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_upt`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_upt') }}
+),
+
+int_total AS (
+    SELECT *
+    FROM `cal-itp-data-infra-staging.tiffany_mart_ntd_explore.int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_total`
+    --{{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_total') }}
+),
+
 upt_agency_identifiers AS (
     SELECT
         key,
@@ -146,8 +180,7 @@ upt_agency_identifiers AS (
         agency_name AS source_agency,
         city AS source_city,
         state AS source_state,
-        --dt,
-        --execution_ts,
+
     FROM int_upt
     GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
 ),
@@ -168,29 +201,13 @@ opexp_agency_identifiers AS (
         agency_name AS source_agency,
         city AS source_city,
         state AS source_state,
-        --dt,
-        --execution_ts,
+
     FROM int_total
     GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
 ),
 
 agency_identifiers AS (
     SELECT * FROM upt_agency_identifiers
-    UNION ALL SELECT * FROM opexp_agency_identifiers
-),
-
-        agency_identifiers.agency_status,
-        agency_identifiers.census_year,
-        agency_identifiers.last_report_year,
-        agency_identifiers.mode_status,
-        agency_identifiers.reporter_type,
-        agency_identifiers.reporting_module,
-        agency_identifiers.uace_code,
-        agency_identifiers.uza_area_sq_miles,
-        agency_identifiers.primary_uza_name,
-        agency_identifiers.uza_population,
-        agency_identifiers.source_agency,
-        agency_identifiers.source_city,
-        agency_identifiers.source_state,
-        --agency_identifiers.dt,
-        --agency_identifiers.execution_ts,
+    UNION DISTINCT SELECT * FROM opexp_agency_identifiers
+)
+SELECT * FROM agency_identifiers

--- a/ntd/annual.sql
+++ b/ntd/annual.sql
@@ -99,6 +99,15 @@ service_data_and_operating_expenses_time_series_by_mode AS (
         int_ga.opexp_ga AS operating_expenses_general_administration,
         int_total.opexp_total AS operating_expenses_total,
 
+        -- check these
+        ROUND(SAFE_DIVIDE(int_total.opexp_total, int_vrh.vrh), 2) AS opex_per_vrh, -- should these be inflation-adjusted?
+        ROUND(SAFE_DIVIDE(int_total.opexp_total, int_vrm.vrm, 2) AS opex_per_vrm,
+        ROUND(SAFE_DIVIDE(int_total.opexp_total, int_upt.upt, 2) AS opex_per_upt,
+        ROUND(SAFE_DIVIDE(int_upt.upt, int_vrh.vrh, 2) AS upt_per_vrh,
+        ROUND(SAFE_DIVIDE(int_upt.upt, int_vrm.vrm, 2) AS upt_per_vrm,
+        --TODO: add fares
+        --ROUND(SAFE_DIVIDE(int_upt.fares, int_vrm.opexp_total, 2) AS farebox_recovery_ratio,
+
         int_agency_information.agency_status,
         int_agency_information.census_year,
         int_agency_information.last_report_year,
@@ -211,3 +220,6 @@ agency_identifiers AS (
     UNION DISTINCT SELECT * FROM opexp_agency_identifiers
 )
 SELECT * FROM agency_identifiers
+
+----------------------------------------------------------
+----------------------------------------------------------

--- a/ntd/annual.sql
+++ b/ntd/annual.sql
@@ -1,0 +1,91 @@
+----------------------------------------------------------
+-- (1)
+-- fct_service_data_and_operating_expenses_time_series_by_mode_upt/voms/vrh feel repetitive
+-- what's there: noticed that intermediate tables all use `dim_agency_information`
+-- what I want to change: combine the intermediate tables, then bring in dim_agency_information, and filter out bad keys
+----------------------------------------------------------
+WITH int_mode_upt AS (
+    SELECT *
+    FROM {{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_upt') }}
+),
+
+int_mode_vrh AS (
+    SELECT *
+    FROM {{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_vrh') }}
+),
+
+int_mode_vrm AS (
+    SELECT *
+    FROM {{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_vrm') }}
+),
+
+int_mode_voms AS (
+    SELECT *
+    FROM {{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_voms') }}
+),
+
+int_mode_pmt AS (
+    SELECT *
+    FROM {{ ref('int_ntd__service_data_and_operating_expenses_time_series_by_mode_pmt') }}
+),
+
+fct_service_data_and_operating_expenses_time_series_by_mode AS (
+    SELECT
+
+        COALESCE(int_upt.ntd_id, int_vrh.ntd_id, int_vrm.ntd_id, int_voms.ntd_id, int_pmt.ntd_id) AS ntd_id,
+        COALESCE(int_upt.year, int_vrh.year, int_vrm.year, int_voms.year, int_pmt.year) AS year,
+
+        --agency.agency_name,
+        --agency.city,
+        --agency.state,
+        --agency.caltrans_district_current,
+        --agency.caltrans_district_name_current,
+
+        COALESCE(int_upt.mode, int_vrh.mode, int_vrm.mode, int_voms.mode, int_pmt.mode) AS mode,
+        COALESCE(int_upt.type_of_service, int_vrh.type_of_service, int_vrm.type_of_service, int_voms.type_of_service, int_pmt.type_of_service) AS type_of_service,
+        COALESCE(int_upt.agency_status, int_vrh.agency_status, int_vrm.agency_status, int_voms.agency_status, int_pmt.agency_status) AS agency_status,
+        COALESCE(int_upt.census_year, int_vrh.census_year, int_vrm.census_year, int_voms.census_year, int_pmt.census_year) AS census_year,
+        COALESCE(int_upt.last_report_year, int_vrh.last_report_year, int_vrm.last_report_year, int_voms.last_report_year, int_pmt.last_report_year) AS last_report_year,
+        COALESCE(int_upt.mode_status, int_vrh.mode_status, int_vrm.mode_status, int_voms.mode_status, int_pmt.mode_status) AS mode_status,
+        COALESCE(int_upt.last_report_year, int_vrh.last_report_year, int_vrm.last_report_year, int_voms.last_report_year, int_pmt.last_report_year) AS last_report_year,
+        COALESCE(int_upt.reporter_type, int_vrh.reporter_type, int_vrm.reporter_type, int_voms.reporter_type, int_pmt.reporter_type) AS reporter_type,
+
+        --int.reporting_module,
+        --int.uace_code,
+        --int.uza_area_sq_miles,
+        --int.primary_uza_name,
+        --int.uza_population,
+        --int.agency_name AS source_agency,
+        --int.city AS source_city,
+        --int.state AS source_state,
+
+        int_mode_upt.upt,
+        int_mode_vrh.vrh,
+        int_mode_vrm.vrm,
+        int_mode_voms.voms,
+
+        int.dt, -- are these the same across all the datasets?
+        int.execution_ts -- are these the same across all the datasets?
+    FROM int_mode_upt
+    LEFT JOIN int_mode_vrh
+        USING (key)
+    LEFT JOIN int_mode_vrm
+        USING (key)
+    LEFT JOIN int_mode_voms
+        USING (key)
+    LEFT JOIN int_mode_pmt
+        USING (key)
+
+    --LEFT JOIN dim_agency_information AS agency
+        ON int.ntd_id = agency.ntd_id
+            AND int.year = agency.year
+    -- remove bad rows for 'Advance Transit, Inc. NH' and 'Southern Teton Area Rapid Transit'
+    WHERE int.key NOT IN ('e41f3812655066d28ec4bbc851545517','f5f160d19e3753e3a99d9ad55b4f2210','7d3e30725b3fa42c6d1722308f9cc855',
+        'da108425cb2696446aa1017bca72340f','a31019318eddb35b747ab79470e10017','98692053a5a16aae8ef8e2579f19b8a3',
+        'd6809f84a9d19808f8b1f013fc1cd537','c3ae0b0299c10ffa25e1193404762136','564993fcc3a920cc0800005f3af9fd73',
+        '73f01d2aa1c268ec1dafbcf1fdaa84fc','5b13563073a95faa05c9da4f77c0b3a8','0fab2ef186a2a74edc98d16427d4d61a')
+)
+
+-- step 1 sanity check:
+-- do all the left joins work? do any rows drop? if nothing, can it be inner join?
+-- the keys are dbt_utils.generate_surrogate_key(['ntd_id', 'year', 'mode', 'type_of_service']) }}

--- a/ntd/notes.md
+++ b/ntd/notes.md
@@ -2,9 +2,14 @@
 
 **Goal**: describe what each script does, then replicate with streamlined and consolidated dbt models.
 Make sure models adhere to grains in the warehouse and capture as much of the needed columns as possible.
-* monthly ridership: TODO URL
-* annual ridership: TODO URL
-* UCLA performance metrics: TODO URL
+* monthly ridership: https://github.com/cal-itp/data-analyses/blob/main/ntd/monthly_ridership_report/monthly_ridership_by_rtpa.py
+* annual ridership: https://github.com/cal-itp/data-analyses/blob/main/ntd/annual_ridership_report/annual_ridership_script.py
+* UCLA performance metrics: https://github.com/cal-itp/data-analyses/blob/main/ntd/new_transit_metrics/new_transit_metrics_utils.py
+* utils: https://github.com/cal-itp/data-analyses/blob/main/ntd/ridership_report_utils/_01_ntd_ridership_utils.py
+* annual tables (annual ridership + UCLA performance metrics) came from different time-series sheets, so from `stg -> int`, these are separate models for each metric.
+   * `fct` doesn't need to maintain the fanout, it can be brought together, so metrics can be calculated with needed columns side-by-side.
+   * currently, `fct` just merges in `dim_agency_information` and filters out bad keys, and does this repeatedly, across 10 models. the `int` models can be brought in together to 1 `fct` table, eliminate sprawl.
+   * `fct` tables constructed this way wasn't a request based on use, so this can get refactored to match how it's used.
 
 ## Monthly Ridership by RTPA
 1. monthly ridership agency-mode-tos grain data: `mart_ntd_ridership.fct_complete_monthly_ridership_with_adjustments_and_estimates`

--- a/ntd/notes.md
+++ b/ntd/notes.md
@@ -1,0 +1,69 @@
+# NTD scripts to dbt models
+
+**Goal**: describe what each script does, then replicate with streamlined and consolidated dbt models.
+Make sure models adhere to grains in the warehouse and capture as much of the needed columns as possible.
+* monthly ridership: TODO URL
+* annual ridership: TODO URL
+* UCLA performance metrics: TODO URL
+
+## Monthly Ridership by RTPA
+1. monthly ridership agency-mode-tos grain data: `mart_ntd_ridership.fct_complete_monthly_ridership_with_adjustments_and_estimates`
+   * filter for years (2018-), state (CA), non-nulls
+   * crosswalk (SCAG is split out by county) - use new bridge table
+1. TODO define grain for operating expenses: `mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_upt`
+   * filter for years (2018-), state (CA) using UZA
+1. Merge ridership with operator expenses
+1. Merge in crosswalk
+   * Note: Merging on too many columns can create problems because csvs and dtypes aren't stable / consistent for NTD ID, Legacy NTD ID, and UZA
+1. Add columns for report viz
+   * Add change columns - compare to same month_one_year_ago, get change and percent change
+   * Mode and TOS get full names
+1. Save Excel outputs
+   * Prepare some subtotals (Aggregated by Agency / Mode / TOS) as individual sheets
+   * Attach cover sheet
+   * Loop through RTPAs to create Excel worksheet for each
+1. Upload to public GCS
+
+## Annual Ridership by RTPA
+1. annual ridership and operating expenses (agency-mode-tos grain data): `mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_upt`
+   * filter for years (2018-), state (CA) using UZA
+   * there is a group by to sum, so this aggregated grain is what we want
+   * check why columns are not named the same, do values differ? tos vs type_of_service; mode vs mode_name vs _3_mode
+   * make crosswalk (same as monthly)
+1. Merge in crosswalk
+   * There is a separate handling of ntd_ids that belong to LA County Dept of Public Works, they get mapped to a different RTPA? Or they just get flagged as being merged?
+1. Add columns for report viz
+   * Add change columns - compare to same one_year_ago, get change and percent change
+   * Mode and TOS get full names
+1. Save Excel outputs
+   * Prepare some subtotals (Aggregated by Agency / Mode / TOS / Reporter Type) as individual sheets
+   * Attach cover sheet
+   * Loop through RTPAs to create Excel worksheet for each
+1. Upload to public GCS
+
+## UCLA NTD Performance Metrics
+1. annual operating expenses (agency-mode grain data): `mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_opexp_total`
+   * filter for years (2018-), state (CA) using UZA, non-nulls
+   * check mode vs mode_status? agency_status? reporter_type? is that used in annual ridership?
+   * upt, vrh, vrm tables have a clear lineage, but feels really repetitive
+1. annual **upt** agency-mode grain data:  `mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_upt`
+1. annual **vrh** agency-mode grain data: `mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_vrh`
+1. annual **vrm** agency-mode grain data: `mart_ntd_funding_and_expenses.fct_service_data_and_operating_expenses_time_series_by_mode_vrm`
+1. Merge in crosswalk
+1. Add columns for report viz
+   * Mode, service (why isn't this called tos) -> TOS get full names
+   * dtypes wrangling: integrify
+   * These were used in notebook:
+   ```
+   rename_cols={
+        'upt':"Unlinked Passenger Trips",
+        'vrm':"Vehicle Revenue Miles",
+        'vrh':"Vehicle Revenue Hours",
+        'opexp_total':"Operating Expense Total",
+        'opex_per_vrh':"Operating Expense per Vehicle Revenue Hours",
+        'opex_per_vrm':"Operating Expense per Vehicle Revenue Miles",
+        'opex_per_upt':"Operating Expense per Unlinked Passenger Trips",
+        'upt_per_vrh':"Unlinked Passenger Trips per Vehicle Revenue Hours",
+        'upt_per_vrm':"Unlinked Passenger Trips per Vehicle Revenue Miles",
+    }
+   ```


### PR DESCRIPTION
## conceptual map
* write out what's done in existing workflow to see where there are sections that look similar. 
* needed for both annual and monthly: crosswalk (but `rtpa_name` is not the same for both, where LA County DPW gets broken out further in one)
* annual: used in annual report + UCLA performance metrics
   * start here, as warehouse models feel like sprawl. much of the Python scripts reflect what's already there in the warehouse, to simplify the scripts, we have to simplify the models and do those joins in `fct`.
   * they can be combined for `fct`, but right now, they are individual models. makes sense to keep `stg -> int` with the fanout for each metric, can trace it back to source data.

## NTD annual models
* right now, there are 12 metrics hanging out 12 `fct` tables, 12 `int` tables, and 12 `stg` tables.
   * service values: `upt, vrh, vrm, voms, pmt, drm`
   * funding values: `vo, vm, nvm, ga, total`
   * fares: `fares`
* one `fct` table can bring all the metrics together, as well as calculate new metrics. (can remove those 11 `fct` tables once sanity check is done to make sure it's equivalent)
   * joins across these tables are equivalent
   * bringing in bridge table will change rows, this needs sanity check 
* this can get even closer to how it's being used. will still need to bring in `dim_annual_agency`.
* need to add a new `bridge` table for NTD to county to RTPA to organization.
   * remove the need for `dim_annual_agency` for dupes in script shouldn't be needed -> using dimension tables results in this, so move to labeling instead.
* starting point for Python scripts will bring in new annual model, bridge, merge those, and can go straight to aggregating and visualizing it by agency, by mode, by TOS.
   * the functions here can be cleaned up too to better serve annual and monthly models
   * aggregations and Excel outputs are equivalent structurally 
