### PR TITLE
Update legislative to operator crosswalk

### DIFF
--- a/gtfs_digest/01_legislative_district.ipynb
+++ b/gtfs_digest/01_legislative_district.ipynb
@@ -1,0 +1,373 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bcb2d618-ae11-49b0-9f61-fb61cf1271f1",
+   "metadata": {},
+   "source": [
+    "# Use `fct_monthly_routes` to make legislative district crosswalk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c1024c83-08c7-4013-9e4d-e71960b3b6d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import gcsfs\n",
+    "import google.auth\n",
+    "import pandas as pd\n",
+    "\n",
+    "from update_vars import DIGEST_DICT, RAW_GCS, abbrev_month\n",
+    "\n",
+    "credentials, _ = google.auth.default()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1fba0828-b40a-47f0-80be-d1900b1c573b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = f\"{RAW_GCS}{DIGEST_DICT.route_map}_{abbrev_month}.parquet\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6d02ab73-6e09-4ada-a361-bfa9d9f8deb2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf = gpd.read_parquet(\n",
+    "    filename, storage_options = {\"token\": credentials.token},\n",
+    "    columns = [\n",
+    "        \"schedule_name\", \"analysis_name\", \"geometry\"\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "# fct_monthly_routes for digest contains 2 months, current month and prior month"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "85a79347-524a-481d-b7b3-c90cc53682ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>schedule_name</th>\n",
+       "      <th>analysis_name</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Bay Area 511 SamTrans Schedule</td>\n",
+       "      <td>San Mateo County Transit District</td>\n",
+       "      <td>LINESTRING (-122.42774 37.62222, -122.42771 37...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>GET Schedule</td>\n",
+       "      <td>Golden Empire Transit District</td>\n",
+       "      <td>LINESTRING (-118.97323 35.41105, -118.97251 35...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    schedule_name                      analysis_name  \\\n",
+       "0  Bay Area 511 SamTrans Schedule  San Mateo County Transit District   \n",
+       "1                    GET Schedule     Golden Empire Transit District   \n",
+       "\n",
+       "                                            geometry  \n",
+       "0  LINESTRING (-122.42774 37.62222, -122.42771 37...  \n",
+       "1  LINESTRING (-118.97323 35.41105, -118.97251 35...  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gdf.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b64b1f11-c6f0-44d5-bc88-a1c92a92eabc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SHARED_GCS = \"gs://calitp-analytics-data/data-analyses/shared_data/\"\n",
+    "legislative_districts = gpd.read_parquet(\n",
+    "    f\"{SHARED_GCS}legislative_districts.parquet\",\n",
+    "    storage_options = {\"token\": credentials.token}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c4ab965f-1f7b-466d-8367-9842a066a328",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sjoin_shapes_legislative_districts(\n",
+    "    shapes_gdf: gpd.GeoDataFrame\n",
+    ") -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Grab shapes (fct_monthly_routes or daily shapes) and do a spatial join\n",
+    "    with legislative district.\n",
+    "    Keep 1 row for every operator-legislative_district combination.\n",
+    "    \"\"\"\n",
+    "    legislative_districts = gpd.read_parquet(\n",
+    "        f\"{SHARED_GCS}legislative_districts.parquet\",\n",
+    "        storage_options = {\"token\": credentials.token}\n",
+    "    )\n",
+    "    \n",
+    "    crosswalk = gpd.sjoin(\n",
+    "        shapes_gdf, legislative_districts, \n",
+    "        how=\"inner\", \n",
+    "        predicate=\"intersects\"\n",
+    "    )[[\"schedule_name\", \"analysis_name\", \"legislative_district\"]\n",
+    "    ].drop_duplicates().sort_values(\n",
+    "        [\"schedule_name\", \"legislative_district\"]\n",
+    "    ).reset_index(drop=True)\n",
+    "\n",
+    "    return crosswalk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "806ac461-f88a-47b1-b764-b0d4201d444f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crosswalk = sjoin_shapes_legislative_districts(gdf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "000740ac-1d33-4b76-b4c7-ebdf622c056e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(152, 2)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "crosswalk[[\"schedule_name\", \"analysis_name\"]].drop_duplicates().shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b988fc4-60a9-47ad-8b58-3eea0c608dd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# all operators were mapped onto crosswalk, good, and most span multiple (expected)\n",
+    "gdf[[\"schedule_name\", \"analysis_name\"]].drop_duplicates().shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "92aabb12-661d-45d0-a572-0079b623719c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>schedule_name</th>\n",
+       "      <th>analysis_name</th>\n",
+       "      <th>legislative_district</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Alhambra Schedule</td>\n",
+       "      <td>City of Alhambra</td>\n",
+       "      <td>AD 49</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Alhambra Schedule</td>\n",
+       "      <td>City of Alhambra</td>\n",
+       "      <td>AD 52</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Alhambra Schedule</td>\n",
+       "      <td>City of Alhambra</td>\n",
+       "      <td>SD 25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Alhambra Schedule</td>\n",
+       "      <td>City of Alhambra</td>\n",
+       "      <td>SD 26</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Amador Schedule</td>\n",
+       "      <td>Amador Regional Transit System</td>\n",
+       "      <td>AD 01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Amador Schedule</td>\n",
+       "      <td>Amador Regional Transit System</td>\n",
+       "      <td>AD 09</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Amador Schedule</td>\n",
+       "      <td>Amador Regional Transit System</td>\n",
+       "      <td>SD 04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Antelope Valley Transit Authority Schedule</td>\n",
+       "      <td>Antelope Valley Transit Authority</td>\n",
+       "      <td>AD 34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Antelope Valley Transit Authority Schedule</td>\n",
+       "      <td>Antelope Valley Transit Authority</td>\n",
+       "      <td>AD 39</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>Antelope Valley Transit Authority Schedule</td>\n",
+       "      <td>Antelope Valley Transit Authority</td>\n",
+       "      <td>AD 40</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                schedule_name  \\\n",
+       "0                           Alhambra Schedule   \n",
+       "1                           Alhambra Schedule   \n",
+       "2                           Alhambra Schedule   \n",
+       "3                           Alhambra Schedule   \n",
+       "4                             Amador Schedule   \n",
+       "5                             Amador Schedule   \n",
+       "6                             Amador Schedule   \n",
+       "7  Antelope Valley Transit Authority Schedule   \n",
+       "8  Antelope Valley Transit Authority Schedule   \n",
+       "9  Antelope Valley Transit Authority Schedule   \n",
+       "\n",
+       "                       analysis_name legislative_district  \n",
+       "0                   City of Alhambra                AD 49  \n",
+       "1                   City of Alhambra                AD 52  \n",
+       "2                   City of Alhambra                SD 25  \n",
+       "3                   City of Alhambra                SD 26  \n",
+       "4     Amador Regional Transit System                AD 01  \n",
+       "5     Amador Regional Transit System                AD 09  \n",
+       "6     Amador Regional Transit System                SD 04  \n",
+       "7  Antelope Valley Transit Authority                AD 34  \n",
+       "8  Antelope Valley Transit Authority                AD 39  \n",
+       "9  Antelope Valley Transit Authority                AD 40  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "crosswalk.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b58e663d-df13-4bec-a0d9-57272aadf12c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Pyproject Local (use-venv)",
+   "language": "python",
+   "name": "pyproject_local_kernel_use_venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gtfs_digest/crosswalk_legislative_district.py
+++ b/gtfs_digest/crosswalk_legislative_district.py
@@ -1,0 +1,44 @@
+""" """
+
+import geopandas as gpd
+import google.auth
+import pandas as pd
+from update_vars import DIGEST_DICT, RAW_GCS, abbrev_month
+
+credentials, _ = google.auth.default()
+SHARED_GCS = "gs://calitp-analytics-data/data-analyses/shared_data/"
+
+
+def sjoin_shapes_legislative_districts(shapes_gdf: gpd.GeoDataFrame) -> pd.DataFrame:
+    """
+    Grab shapes (fct_monthly_routes) and do a spatial join
+    with legislative district.
+    Keep 1 row for every operator-legislative_district combination.
+    """
+    legislative_districts = gpd.read_parquet(
+        f"{SHARED_GCS}legislative_districts.parquet", storage_options={"token": credentials.token}
+    )
+
+    crosswalk = (
+        gpd.sjoin(shapes_gdf, legislative_districts, how="inner", predicate="intersects")[
+            ["schedule_name", "analysis_name", "legislative_district"]
+        ]
+        .drop_duplicates()
+        .sort_values(["schedule_name", "legislative_district"])
+        .reset_index(drop=True)
+    )
+
+    return crosswalk
+
+
+if __name__ == "__main__":
+
+    # how should args be set up so that when this month is run, the crosswalk is made,
+    # and portfolio yaml can be generated off of it?
+    filename = f"{RAW_GCS}{DIGEST_DICT.route_map}_{abbrev_month}.parquet"
+
+    gdf = gpd.read_parquet(
+        filename, storage_options={"token": credentials.token}, columns=["schedule_name", "analysis_name", "geometry"]
+    )
+
+    crosswalk = sjoin_shapes_legislative_districts(gdf)


### PR DESCRIPTION
* One part of Legislative GTFS Digest that has yet to move to `mart_gtfs_rollup` table is the crosswalk that sorts operators into legislative districts https://github.com/cal-itp/data-analyses/issues/2054#issuecomment-4693114630
   * Was part of `shared_utils/shared_data.py`, but this should move into GTFS Digest folder, as it's the only use case
* This can move away from `shared_utils` to further clean up work there
* Will be used in #33 down the line 